### PR TITLE
Optimize request pipeline and caching

### DIFF
--- a/src/artemis/application.py
+++ b/src/artemis/application.py
@@ -387,14 +387,17 @@ class ArtemisApp:
         host = headers.get("host")
         if host is None:
             raise RuntimeError("Host header required for multi-tenant resolution")
-        body = b""
+        body_chunks = bytearray()
         more_body = True
         while more_body:
             message = await receive()
             if message["type"] != "http.request":
                 continue
-            body += message.get("body", b"")
+            chunk = message.get("body", b"")
+            if chunk:
+                body_chunks.extend(chunk)
             more_body = message.get("more_body", False)
+        body = bytes(body_chunks)
         response = await self.dispatch(
             scope["method"],
             scope["path"],

--- a/src/artemis/middleware.py
+++ b/src/artemis/middleware.py
@@ -21,6 +21,9 @@ class Middleware(Protocol):
 
 MiddlewareCallable = Callable[[Request, Handler], Awaitable[Response]]
 
+_PipelineKey = tuple[MiddlewareCallable, ...]
+_PIPELINE_CACHE: dict[_PipelineKey, "_MiddlewarePipeline"] = {}
+
 
 def apply_middleware(
     middlewares: Iterable[MiddlewareCallable],
@@ -31,34 +34,108 @@ def apply_middleware(
 ) -> Handler:
     """Compose middleware into a single handler."""
 
-    composed = endpoint
-    for middleware in reversed(tuple(middlewares)):
-        composed = _wrap_middleware(
-            middleware,
-            composed,
-            observability=observability,
-            request_context=request_context,
-        )
-    return composed
+    normalized = _normalize_middlewares(middlewares)
+    if not normalized:
+        return endpoint
+    pipeline = _PIPELINE_CACHE.get(normalized)
+    if pipeline is None:
+        pipeline = _MiddlewarePipeline(normalized)
+        _PIPELINE_CACHE[normalized] = pipeline
+    return pipeline.bind(endpoint, observability=observability, request_context=request_context)
 
 
-def _wrap_middleware(
-    middleware: MiddlewareCallable,
-    handler: Handler,
-    *,
-    observability: "Observability | None" = None,
-    request_context: "_ObservationContext | None" = None,
-) -> Handler:
-    async def wrapped(request: Request) -> Response:
+def _normalize_middlewares(middlewares: Iterable[MiddlewareCallable]) -> _PipelineKey:
+    if isinstance(middlewares, tuple):
+        return middlewares
+    return tuple(middlewares)
+
+
+class _MiddlewarePipeline:
+    __slots__ = ("_middlewares",)
+
+    def __init__(self, middlewares: _PipelineKey) -> None:
+        self._middlewares = middlewares
+
+    def bind(
+        self,
+        endpoint: Handler,
+        *,
+        observability: "Observability | None" = None,
+        request_context: "_ObservationContext | None" = None,
+    ) -> Handler:
+        return _BoundPipeline(self, endpoint, observability, request_context)
+
+    async def _invoke(
+        self,
+        index: int,
+        request: Request,
+        endpoint: Handler,
+        observability: "Observability | None",
+        request_context: "_ObservationContext | None",
+    ) -> Response:
+        if index >= len(self._middlewares):
+            return await endpoint(request)
+        middleware = self._middlewares[index]
+        next_handler = _NextHandler(self, index + 1, endpoint, observability, request_context)
         if observability is None or not observability.enabled:
-            return await middleware(request, handler)
+            return await middleware(request, next_handler)
         context = observability.on_middleware_start(middleware, request, request_context)
         try:
-            response = await middleware(request, handler)
+            response = await middleware(request, next_handler)
         except Exception as exc:
             observability.on_middleware_error(context, exc)
             raise
         observability.on_middleware_success(context)
         return response
 
-    return wrapped
+
+class _BoundPipeline:
+    __slots__ = ("_endpoint", "_observability", "_pipeline", "_request_context")
+
+    def __init__(
+        self,
+        pipeline: _MiddlewarePipeline,
+        endpoint: Handler,
+        observability: "Observability | None",
+        request_context: "_ObservationContext | None",
+    ) -> None:
+        self._pipeline = pipeline
+        self._endpoint = endpoint
+        self._observability = observability
+        self._request_context = request_context
+
+    async def __call__(self, request: Request) -> Response:
+        return await self._pipeline._invoke(
+            0,
+            request,
+            self._endpoint,
+            self._observability,
+            self._request_context,
+        )
+
+
+class _NextHandler:
+    __slots__ = ("_endpoint", "_index", "_observability", "_pipeline", "_request_context")
+
+    def __init__(
+        self,
+        pipeline: _MiddlewarePipeline,
+        index: int,
+        endpoint: Handler,
+        observability: "Observability | None",
+        request_context: "_ObservationContext | None",
+    ) -> None:
+        self._pipeline = pipeline
+        self._index = index
+        self._endpoint = endpoint
+        self._observability = observability
+        self._request_context = request_context
+
+    async def __call__(self, request: Request) -> Response:
+        return await self._pipeline._invoke(
+            self._index,
+            request,
+            self._endpoint,
+            self._observability,
+            self._request_context,
+        )


### PR DESCRIPTION
## Summary
- lazily parse request query strings and cache type hints to reduce overhead on hot paths
- precompute middleware, dependency, routing, observability, and RBAC structures for faster request handling
- add static asset compression caching and comprehensive tests ensuring full coverage

## Testing
- `uv run ruff check`
- `uv run ty check`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d283c83870832e82ae616ed9ef54b9