### PR TITLE
Add SSE and WebSocket infrastructure

### DIFF
--- a/src/artemis/__init__.py
+++ b/src/artemis/__init__.py
@@ -32,6 +32,7 @@ from .database import (
     TLSConfig,
 )
 from .dependency import DependencyProvider
+from .events import EventStream, ServerSentEvent
 from .exceptions import ArtemisError, HTTPError
 from .http import (
     Status,
@@ -124,6 +125,7 @@ from .routing import get, post, route
 from .static import StaticFiles
 from .tenancy import TenantContext, TenantResolver, TenantScope
 from .testing import TestClient
+from .websockets import WebSocket, WebSocketDisconnect
 
 __all__ = [
     "DEFAULT_SECURITY_HEADERS",
@@ -161,6 +163,7 @@ __all__ = [
     "DatabaseCredentials",
     "DatabaseModel",
     "DependencyProvider",
+    "EventStream",
     "FederatedIdentityDirectory",
     "FederatedProvider",
     "HTTPError",
@@ -197,6 +200,7 @@ __all__ = [
     "SecretRef",
     "SecretResolver",
     "SecretValue",
+    "ServerSentEvent",
     "SessionLevel",
     "SessionToken",
     "SlackWebhookConfig",
@@ -216,6 +220,8 @@ __all__ = [
     "TenantUser",
     "TestClient",
     "UserRole",
+    "WebSocket",
+    "WebSocketDisconnect",
     "apply_default_security_headers",
     "attach_quickstart",
     "audit_context",

--- a/src/artemis/application.py
+++ b/src/artemis/application.py
@@ -613,14 +613,10 @@ async def _send_response_body(
     except StopAsyncIteration:
         await send({"type": "http.response.body", "body": response.body, "more_body": False})
         return
-    while True:
-        try:
-            next_chunk = await anext(iterator)
-        except StopAsyncIteration:
-            await send({"type": "http.response.body", "body": chunk, "more_body": False})
-            break
+    await send({"type": "http.response.body", "body": chunk, "more_body": True})
+    async for chunk in iterator:
         await send({"type": "http.response.body", "body": chunk, "more_body": True})
-        chunk = next_chunk
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
 def _ensure_async_iterator(stream: AsyncIterable[bytes]) -> AsyncIterator[bytes]:

--- a/src/artemis/application.py
+++ b/src/artemis/application.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import os
+from collections.abc import AsyncIterable, AsyncIterator
 from typing import Any, Awaitable, Callable, Dict, Iterable, Mapping, Sequence
 
 import msgspec
@@ -13,6 +14,7 @@ from .chatops import ChatOpsService
 from .config import AppConfig
 from .database import Database
 from .dependency import DependencyProvider
+from .events import EventStream
 from .exceptions import HTTPError
 from .execution import TaskExecutor
 from .http import Status
@@ -31,8 +33,9 @@ from .responses import (
 )
 from .routing import RouteGuard, Router
 from .static import StaticFiles
-from .tenancy import TenantContext, TenantResolver
+from .tenancy import TenantContext, TenantResolutionError, TenantResolver
 from .typing_utils import convert_primitive
+from .websockets import WebSocket, WebSocketDisconnect
 
 Handler = Callable[[Request], Awaitable[Response]]
 
@@ -132,6 +135,24 @@ class ArtemisApp:
         authorize: RouteGuard | Sequence[RouteGuard] | None = None,
     ) -> Callable[[Callable[..., Awaitable[Any] | Any]], Callable[..., Awaitable[Any] | Any]]:
         return self.route(path, methods=("POST",), name=name, authorize=authorize)
+
+    def sse(
+        self,
+        path: str,
+        *,
+        name: str | None = None,
+        authorize: RouteGuard | Sequence[RouteGuard] | None = None,
+    ) -> Callable[[Callable[..., Awaitable[Any] | Any]], Callable[..., Awaitable[Any] | Any]]:
+        return self.route(path, methods=("GET",), name=name, authorize=authorize)
+
+    def websocket(
+        self,
+        path: str,
+        *,
+        name: str | None = None,
+        authorize: RouteGuard | Sequence[RouteGuard] | None = None,
+    ) -> Callable[[Callable[..., Awaitable[Any] | Any]], Callable[..., Awaitable[Any] | Any]]:
+        return self.route(path, methods=("WEBSOCKET",), name=name, authorize=authorize)
 
     def mount_static(
         self,
@@ -297,6 +318,7 @@ class ArtemisApp:
     async def _execute_route(self, route, request: Request, scope) -> Response:
         await self._authorize_route(route, request, scope)
         call_args: Dict[str, Any] = {}
+        event_streams: list[EventStream] = []
         body_payload: Any | None = None
         for name, parameter in route.signature.parameters.items():
             annotation = route.type_hints.get(name, parameter.annotation)
@@ -307,6 +329,11 @@ class ArtemisApp:
                 continue
             if annotation is TenantContext:
                 call_args[name] = request.tenant
+                continue
+            if annotation is EventStream:
+                stream = EventStream(executor=self.executor)
+                call_args[name] = stream
+                event_streams.append(stream)
                 continue
             if name in route.param_names:
                 value = request.path_params[name]
@@ -330,7 +357,46 @@ class ArtemisApp:
         result = route.spec.endpoint(**call_args)
         if inspect.isawaitable(result):
             result = await result
+        if result is None and event_streams:
+            if len(event_streams) > 1:
+                raise RuntimeError("Multiple EventStream parameters require explicit return value")
+            result = event_streams[0]
         return _coerce_response(result)
+
+    async def _execute_websocket_route(self, route, websocket: WebSocket, scope) -> None:
+        call_args: Dict[str, Any] = {}
+        for name, parameter in route.signature.parameters.items():
+            annotation = route.type_hints.get(name, parameter.annotation)
+            if annotation is inspect.Signature.empty:
+                annotation = str if name in route.param_names else Any
+            if annotation is WebSocket:
+                call_args[name] = websocket
+                continue
+            if annotation is Request:
+                call_args[name] = websocket.request
+                continue
+            if annotation is TenantContext:
+                call_args[name] = websocket.request.tenant
+                continue
+            if name in route.param_names:
+                value = websocket.request.path_params[name]
+                if annotation is str or annotation is Any:
+                    call_args[name] = value
+                else:
+                    call_args[name] = convert_primitive(value, annotation, source=name)
+                continue
+            try:
+                call_args[name] = await scope.get(annotation)
+            except LookupError as exc:
+                raise HTTPError(
+                    Status.INTERNAL_SERVER_ERROR,
+                    {"dependency": repr(annotation), "detail": str(exc)},
+                ) from exc
+        result = route.spec.endpoint(**call_args)
+        if inspect.isawaitable(result):
+            result = await result
+        if result not in (None, websocket):
+            raise RuntimeError("WebSocket handlers must not return a value")
 
     async def _authorize_route(self, route, request: Request, scope) -> None:
         if not route.guards:
@@ -383,8 +449,21 @@ class ArtemisApp:
         receive: Callable[[], Awaitable[Mapping[str, Any]]],
         send: Callable[[Mapping[str, Any]], Awaitable[None]],
     ) -> None:
-        if scope.get("type") != "http":
-            raise RuntimeError("ArtemisApp only supports HTTP scopes")
+        scope_type = scope.get("type")
+        if scope_type == "http":
+            await self._handle_http(scope, receive, send)
+            return
+        if scope_type == "websocket":
+            await self._handle_websocket(scope, receive, send)
+            return
+        raise RuntimeError("ArtemisApp only supports HTTP and WebSocket scopes")
+
+    async def _handle_http(
+        self,
+        scope: Mapping[str, Any],
+        receive: Callable[[], Awaitable[Mapping[str, Any]]],
+        send: Callable[[Mapping[str, Any]], Awaitable[None]],
+    ) -> None:
         headers = {key.decode().lower(): value.decode() for key, value in scope.get("headers", [])}
         host = headers.get("host")
         if host is None:
@@ -435,12 +514,75 @@ class ArtemisApp:
                 "headers": [(k.encode("latin-1"), v.encode("latin-1")) for k, v in response.headers],
             }
         )
-        await send(
-            {
-                "type": "http.response.body",
-                "body": response.body,
-            }
+        await _send_response_body(response, send)
+
+    async def _handle_websocket(
+        self,
+        scope: Mapping[str, Any],
+        receive: Callable[[], Awaitable[Mapping[str, Any]]],
+        send: Callable[[Mapping[str, Any]], Awaitable[None]],
+    ) -> None:
+        headers = {key.decode().lower(): value.decode() for key, value in scope.get("headers", [])}
+        host = headers.get("host")
+        if host is None:
+            await send({"type": "websocket.close", "code": 4400})
+            return
+        try:
+            tenant = self.tenant_resolver.resolve(host)
+        except (LookupError, TenantResolutionError):
+            await send({"type": "websocket.close", "code": 4404})
+            return
+        path = scope.get("path", "")
+        try:
+            match = self.router.find("WEBSOCKET", path)
+        except LookupError:
+            await send({"type": "websocket.close", "code": 4404})
+            return
+        request = Request(
+            method="WEBSOCKET",
+            path=path,
+            headers=headers,
+            tenant=tenant,
+            path_params=match.params,
+            query_string=(scope.get("query_string") or b"").decode(),
         )
+        scope_obj = self.dependencies.scope(request)
+        websocket = WebSocket(
+            scope=scope,
+            receive=receive,
+            send=send,
+            request=request,
+            executor=self.executor,
+        )
+        try:
+            initial = await receive()
+        except Exception:
+            await websocket.close(code=1011)
+            raise
+        message_type = initial.get("type")
+        if message_type == "websocket.disconnect":
+            return
+        if message_type != "websocket.connect":
+            await websocket.close(code=4400)
+            return
+        try:
+            await self._authorize_route(match.route, request, scope_obj)
+        except HTTPError as exc:
+            await websocket.close(code=_status_to_websocket_close(exc.status))
+            return
+        try:
+            await self._execute_websocket_route(match.route, websocket, scope_obj)
+        except HTTPError as exc:
+            await websocket.close(code=_status_to_websocket_close(exc.status))
+        except WebSocketDisconnect:
+            pass
+        except Exception:
+            await websocket.close(code=1011)
+            raise
+        finally:
+            await websocket.join_background()
+            if not websocket.closed:
+                await websocket.close()
 
 
 class Artemis(ArtemisApp):
@@ -457,9 +599,58 @@ def _is_struct(annotation: Any) -> bool:
     return isinstance(annotation, type) and issubclass(annotation, msgspec.Struct)
 
 
+async def _send_response_body(
+    response: Response,
+    send: Callable[[Mapping[str, Any]], Awaitable[None]],
+) -> None:
+    stream = response.stream
+    if stream is None:
+        await send({"type": "http.response.body", "body": response.body})
+        return
+    iterator = _ensure_async_iterator(stream)
+    try:
+        chunk = await anext(iterator)
+    except StopAsyncIteration:
+        await send({"type": "http.response.body", "body": response.body, "more_body": False})
+        return
+    while True:
+        try:
+            next_chunk = await anext(iterator)
+        except StopAsyncIteration:
+            await send({"type": "http.response.body", "body": chunk, "more_body": False})
+            break
+        await send({"type": "http.response.body", "body": chunk, "more_body": True})
+        chunk = next_chunk
+
+
+def _ensure_async_iterator(stream: AsyncIterable[bytes]) -> AsyncIterator[bytes]:
+    if isinstance(stream, AsyncIterator):
+        return stream
+    return stream.__aiter__()
+
+
+def _status_to_websocket_close(status: int | Status) -> int:
+    code = int(status)
+    mapping = {
+        400: 4400,
+        401: 4401,
+        403: 4403,
+        404: 4404,
+    }
+    if code in mapping:
+        return mapping[code]
+    if 400 <= code < 500:
+        return 4400
+    if 500 <= code < 600:
+        return 1011
+    return 1008
+
+
 def _coerce_response(result: Any) -> Response:
     if isinstance(result, Response):
         return result
+    if isinstance(result, EventStream):
+        return result.to_response()
     if result is None:
         return apply_default_security_headers(Response(status=int(Status.NO_CONTENT), body=b""))
     if isinstance(result, str):

--- a/src/artemis/events.py
+++ b/src/artemis/events.py
@@ -1,0 +1,248 @@
+"""Server-sent event helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from collections.abc import AsyncIterator, Iterable, Mapping
+from typing import Any, Awaitable, Callable, cast
+
+import msgspec
+
+from .execution import ExecutionMode, TaskExecutor
+from .http import Status
+from .responses import Response, apply_default_security_headers
+from .serialization import json_encode
+
+logger = logging.getLogger(__name__)
+
+
+class ServerSentEvent(msgspec.Struct, frozen=True):
+    """Structured representation of a server-sent event payload."""
+
+    data: Any
+    event: str | None = None
+    event_id: str | None = None
+    retry: int | None = None
+    json: bool = False
+
+
+class EventStream:
+    """Manage streaming server-sent events to the client."""
+
+    _SENTINEL = object()
+
+    def __init__(self, *, executor: TaskExecutor | None = None) -> None:
+        self._queue: asyncio.Queue[bytes | object] = asyncio.Queue()
+        self._executor = executor
+        self._owns_executor = False
+        self._executor_shutdown = False
+        self._closed = False
+        self._background: set[asyncio.Task[Any]] = set()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    async def send(
+        self,
+        message: ServerSentEvent | Any,
+        *,
+        event: str | None = None,
+        event_id: str | None = None,
+        retry: int | None = None,
+        json: bool = False,
+    ) -> None:
+        """Queue an event for emission to the client."""
+
+        if self._closed:
+            raise RuntimeError("EventStream is closed")
+
+        payload = message
+        payload_event = event
+        payload_id = event_id
+        payload_retry = retry
+        json_mode = json
+        if isinstance(message, ServerSentEvent):
+            payload = message.data
+            if payload_event is None:
+                payload_event = message.event
+            if payload_id is None:
+                payload_id = message.event_id
+            if payload_retry is None:
+                payload_retry = message.retry
+            json_mode = json_mode or message.json
+
+        text = _coerce_event_text(payload, json=json_mode)
+        chunk = _format_sse(text, event=payload_event, event_id=payload_id, retry=payload_retry)
+        await self._queue.put(chunk)
+
+    def to_response(
+        self,
+        *,
+        status: int = int(Status.OK),
+        headers: Iterable[tuple[str, str]] | None = None,
+    ) -> Response:
+        """Convert the stream to an :class:`~artemis.responses.Response`."""
+
+        default_headers: tuple[tuple[str, str], ...] = (
+            ("content-type", "text/event-stream"),
+            ("cache-control", "no-cache"),
+            ("connection", "keep-alive"),
+        )
+        combined = default_headers + tuple(headers or ())
+        response = Response(status=status, headers=combined, body=b"", stream=self._iter_events())
+        return apply_default_security_headers(response)
+
+    async def close(self) -> None:
+        """Signal the end of the stream."""
+
+        if self._closed:
+            return
+        self._closed = True
+        await self._queue.put(self._SENTINEL)
+
+    def fork(
+        self,
+        func: Callable[..., Awaitable[Any] | Any],
+        *args: Any,
+        mode: ExecutionMode | None = None,
+        **kwargs: Any,
+    ) -> asyncio.Task[Any]:
+        """Execute ``func`` in the background and emit any returned events."""
+
+        loop = asyncio.get_running_loop()
+        if mode is None:
+            result = func(*args, **kwargs)
+            if not inspect.isawaitable(result):
+                raise TypeError("Background function must be awaitable when mode is None")
+            awaitable = _ensure_awaitable(result)
+            task = cast(asyncio.Task[Any], asyncio.ensure_future(awaitable))
+        else:
+            executor = self._ensure_executor()
+
+            async def runner() -> None:
+                outcome = await executor.run(func, *args, mode=mode, **kwargs)
+                await self._emit_from_result(outcome)
+            task = loop.create_task(runner())
+        self._background.add(task)
+        task.add_done_callback(self._background.discard)
+        task.add_done_callback(_log_task_error)
+        return task
+
+    async def join_background(self) -> None:
+        """Wait for all background tasks to complete."""
+
+        if self._background:
+            await asyncio.gather(*tuple(self._background), return_exceptions=True)
+        await self._shutdown_executor()
+
+    def _iter_events(self) -> AsyncIterator[bytes]:
+        async def iterator() -> AsyncIterator[bytes]:
+            try:
+                while True:
+                    chunk = await self._queue.get()
+                    if chunk is self._SENTINEL:
+                        break
+                    yield chunk  # type: ignore[misc]
+            finally:
+                await self._finalize()
+
+        return iterator()
+
+    async def _emit_from_result(self, result: Any) -> None:
+        if result is None:
+            return
+        if isinstance(result, ServerSentEvent):
+            await self.send(result)
+            return
+        if isinstance(result, (bytes, bytearray, memoryview)):
+            await self.send(bytes(result))
+            return
+        if isinstance(result, str):
+            await self.send(result)
+            return
+        if isinstance(result, Mapping):
+            await self.send(result, json=True)
+            return
+        if isinstance(result, Iterable) and not isinstance(result, (str, bytes, bytearray, memoryview)):
+            for item in result:
+                await self._emit_from_result(item)
+            return
+        await self.send(result, json=True)
+
+    async def _finalize(self) -> None:
+        self._closed = True
+        pending = [task for task in tuple(self._background) if not task.done()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        await self._shutdown_executor()
+
+    def _ensure_executor(self) -> TaskExecutor:
+        if self._executor is None:
+            self._executor = TaskExecutor()
+            self._owns_executor = True
+        return self._executor
+
+    async def _shutdown_executor(self) -> None:
+        if not self._owns_executor or self._executor is None or self._executor_shutdown:
+            return
+        await self._executor.shutdown()
+        self._executor_shutdown = True
+
+
+def _coerce_event_text(data: Any, *, json: bool) -> str:
+    if json:
+        return json_encode(data).decode("utf-8")
+    if isinstance(data, (bytes, bytearray, memoryview)):
+        return bytes(data).decode("utf-8")
+    return str(data)
+
+
+def _format_sse(
+    data: str,
+    *,
+    event: str | None,
+    event_id: str | None,
+    retry: int | None,
+) -> bytes:
+    lines: list[str] = []
+    if event_id is not None:
+        lines.append(f"id: {event_id}")
+    if event is not None:
+        lines.append(f"event: {event}")
+    payload_lines = data.splitlines()
+    if not payload_lines:
+        payload_lines = [""]
+    if data.endswith("\n"):
+        payload_lines.append("")
+    for line in payload_lines:
+        lines.append(f"data: {line}")
+    if retry is not None:
+        lines.append(f"retry: {retry}")
+    lines.append("")
+    return "\n".join(lines).encode("utf-8")
+
+
+def _log_task_error(task: asyncio.Task[Any]) -> None:
+    if task.cancelled():
+        return
+    try:
+        error = task.exception()
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Background task failed")
+        return
+    if error is not None:
+        logger.exception("Background task failed", exc_info=error)
+
+
+def _ensure_awaitable(result: Awaitable[Any] | Any) -> Awaitable[Any]:
+    if inspect.isawaitable(result):
+        return result  # type: ignore[return-value]
+    raise TypeError("Expected awaitable result")
+
+
+__all__ = ["EventStream", "ServerSentEvent"]

--- a/src/artemis/responses.py
+++ b/src/artemis/responses.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterable
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable
 
 import msgspec
@@ -35,11 +36,17 @@ class Response(msgspec.Struct, frozen=True):
     status: int = int(Status.OK)
     headers: Headers = ()
     body: bytes = b""
+    stream: AsyncIterable[bytes] | None = None
 
     def with_headers(self, headers: Iterable[tuple[str, str]]) -> "Response":
         """Return a new response with ``headers`` appended."""
 
-        return Response(status=self.status, headers=self.headers + tuple(headers), body=self.body)
+        return Response(
+            status=self.status,
+            headers=self.headers + tuple(headers),
+            body=self.body,
+            stream=self.stream,
+        )
 
 
 def apply_default_security_headers(

--- a/src/artemis/websockets.py
+++ b/src/artemis/websockets.py
@@ -1,0 +1,239 @@
+"""WebSocket utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from collections.abc import Iterable, Mapping
+from typing import Any, Awaitable, Callable, TypeVar, cast
+
+import msgspec
+
+from .execution import ExecutionMode, TaskExecutor
+from .requests import Request
+from .serialization import json_decode, json_encode
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class WebSocketDisconnect(Exception):
+    """Raised when the client disconnects from the WebSocket."""
+
+    def __init__(self, code: int | None = None, reason: str | None = None) -> None:
+        message = "WebSocket disconnected"
+        if code is not None:
+            message = f"{message} ({code})"
+        if reason:
+            message = f"{message}: {reason}"
+        super().__init__(message)
+        self.code = code
+        self.reason = reason
+
+
+class WebSocket:
+    """Asynchronous helper around the ASGI WebSocket interface."""
+
+    def __init__(
+        self,
+        *,
+        scope: Mapping[str, Any],
+        receive: Callable[[], Awaitable[Mapping[str, Any]]],
+        send: Callable[[Mapping[str, Any]], Awaitable[None]],
+        request: Request,
+        executor: TaskExecutor | None = None,
+    ) -> None:
+        self.scope = scope
+        self._receive = receive
+        self._send = send
+        self.request = request
+        self._executor = executor
+        self._accepted = False
+        self._closed = False
+        self._close_event = asyncio.Event()
+        self._background: set[asyncio.Task[Any]] = set()
+        self.subprotocols: tuple[str, ...] = tuple(scope.get("subprotocols") or ())
+
+    @property
+    def accepted(self) -> bool:
+        return self._accepted
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    async def accept(
+        self,
+        *,
+        subprotocol: str | None = None,
+        headers: Iterable[tuple[str, str]] | None = None,
+    ) -> None:
+        if self._accepted:
+            return
+        message: dict[str, Any] = {"type": "websocket.accept"}
+        if subprotocol is not None:
+            message["subprotocol"] = subprotocol
+        if headers:
+            message["headers"] = [(k.encode("latin-1"), v.encode("latin-1")) for k, v in headers]
+        await self._send(message)
+        self._accepted = True
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        if self._closed:
+            return
+        payload: dict[str, Any] = {"type": "websocket.close", "code": code}
+        if reason:
+            payload["reason"] = reason
+        await self._send(payload)
+        self._closed = True
+        self._close_event.set()
+        await self._cancel_background()
+
+    async def wait_closed(self) -> None:
+        await self._close_event.wait()
+
+    async def receive(self) -> Mapping[str, Any]:
+        message = await self._receive()
+        message_type = message.get("type")
+        if message_type == "websocket.disconnect":
+            self._closed = True
+            self._close_event.set()
+            await self._cancel_background()
+            raise WebSocketDisconnect(
+                code=cast(int | None, message.get("code")),
+                reason=cast(str | None, message.get("reason")),
+            )
+        return message
+
+    async def receive_text(self) -> str:
+        message = await self.receive()
+        text = message.get("text")
+        if text is None:
+            raise TypeError("Expected text WebSocket frame")
+        return cast(str, text)
+
+    async def receive_bytes(self) -> bytes:
+        message = await self.receive()
+        data = message.get("bytes")
+        if data is None:
+            raise TypeError("Expected binary WebSocket frame")
+        if isinstance(data, bytes):
+            return data
+        return bytes(cast(bytearray | memoryview, data))
+
+    async def receive_json(self, type: type[T] | None = None) -> T | Any:
+        message = await self.receive()
+        text = message.get("text")
+        if text is not None:
+            payload = json_decode(text.encode("utf-8"))
+        else:
+            binary = message.get("bytes") or b""
+            payload = json_decode(cast(bytes, binary))
+        if type is None:
+            return payload
+        return msgspec.convert(payload, type=type)
+
+    async def send_text(self, data: str) -> None:
+        await self._ensure_open()
+        await self._ensure_accepted()
+        await self._send({"type": "websocket.send", "text": data})
+
+    async def send_bytes(self, data: bytes | bytearray | memoryview) -> None:
+        await self._ensure_open()
+        await self._ensure_accepted()
+        await self._send({"type": "websocket.send", "bytes": bytes(data)})
+
+    async def send_json(self, data: Any) -> None:
+        await self._ensure_open()
+        await self._ensure_accepted()
+        payload = json_encode(data).decode("utf-8")
+        await self._send({"type": "websocket.send", "text": payload})
+
+    def fork(
+        self,
+        func: Callable[..., Awaitable[Any] | Any],
+        *args: Any,
+        mode: ExecutionMode | None = None,
+        **kwargs: Any,
+    ) -> asyncio.Task[Any]:
+        loop = asyncio.get_running_loop()
+        if mode is None:
+            result = func(*args, **kwargs)
+            awaitable = _ensure_awaitable(result)
+            task = cast(asyncio.Task[Any], asyncio.ensure_future(awaitable))
+        else:
+            if self._executor is None:
+                raise RuntimeError("TaskExecutor not configured for WebSocket background tasks")
+
+            async def runner() -> None:
+                outcome = await self._executor.run(func, *args, mode=mode, **kwargs)
+                await self._send_from_result(outcome)
+            task = loop.create_task(runner())
+        self._background.add(task)
+        task.add_done_callback(self._background.discard)
+        task.add_done_callback(_log_task_error)
+        return task
+
+    async def join_background(self) -> None:
+        if not self._background:
+            return
+        await asyncio.gather(*tuple(self._background), return_exceptions=True)
+
+    async def _ensure_accepted(self) -> None:
+        if not self._accepted:
+            await self.accept()
+
+    async def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("WebSocket connection is closed")
+
+    async def _send_from_result(self, result: Any) -> None:
+        if result is None:
+            return
+        if isinstance(result, str):
+            await self.send_text(result)
+            return
+        if isinstance(result, (bytes, bytearray, memoryview)):
+            await self.send_bytes(result)
+            return
+        if isinstance(result, Mapping):
+            await self.send_json(result)
+            return
+        if isinstance(result, Iterable) and not isinstance(result, (str, bytes, bytearray, memoryview)):
+            for item in result:
+                await self._send_from_result(item)
+            return
+        await self.send_json(result)
+
+    async def _cancel_background(self) -> None:
+        if not self._background:
+            return
+        pending = [task for task in tuple(self._background) if not task.done()]
+        if not pending:
+            return
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+def _log_task_error(task: asyncio.Task[Any]) -> None:
+    if task.cancelled():
+        return
+    try:
+        error = task.exception()
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("WebSocket background task failed")
+        return
+    if error is not None:
+        logger.exception("WebSocket background task failed", exc_info=error)
+
+
+def _ensure_awaitable(result: Awaitable[Any] | Any) -> Awaitable[Any]:
+    if inspect.isawaitable(result):
+        return result
+    raise TypeError("Background function must be awaitable when mode is None")
+
+
+__all__ = ["WebSocket", "WebSocketDisconnect"]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -269,8 +269,10 @@ async def test_send_response_body_handles_async_iterable() -> None:
     await _send_response_body(response, send)
     assert messages[0]["more_body"] is True
     assert messages[0]["body"] == b"chunk-one"
-    assert messages[1]["more_body"] is False
+    assert messages[1]["more_body"] is True
     assert messages[1]["body"] == b"chunk-two"
+    assert messages[2]["more_body"] is False
+    assert messages[2]["body"] == b""
 
 
 @pytest.mark.asyncio

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping
+
+import pytest
+
+from artemis.application import ArtemisApp, _send_response_body
+from artemis.config import AppConfig
+from artemis.events import EventStream, ServerSentEvent
+from artemis.events import _ensure_awaitable as _ensure_event_awaitable
+from artemis.events import _log_task_error as _log_event_task_error
+from artemis.execution import ExecutionMode
+from artemis.requests import Request
+from artemis.responses import Response
+
+
+@pytest.mark.asyncio
+async def test_event_stream_emits_across_tenants() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.sse("/events/{name}")
+    async def events(name: str, stream: EventStream, request: Request) -> EventStream:
+        async def producer() -> None:
+            await asyncio.sleep(0)
+            await stream.send(
+                ServerSentEvent(
+                    data={"tenant": request.tenant.tenant, "name": name},
+                    event="update",
+                    json=True,
+                )
+            )
+            await stream.close()
+
+        stream.fork(producer)
+        return stream
+
+    await app.startup()
+    hosts: Mapping[str, str] = {
+        "acme": "acme.demo.example.com",
+        "beta": "beta.demo.example.com",
+        "admin": "admin.demo.example.com",
+    }
+    try:
+        for tenant, host in hosts.items():
+            response = await app.dispatch("GET", f"/events/{tenant}", host=host)
+            assert response.stream is not None
+            chunks: list[bytes] = []
+            async for chunk in response.stream:
+                chunks.append(chunk)
+            payload = b"".join(chunks).decode()
+            assert "event: update" in payload
+            data_lines = [line[len("data: ") :] for line in payload.splitlines() if line.startswith("data: ")]
+            assert data_lines
+            event_payload = json.loads(data_lines[-1])
+            assert event_payload["name"] == tenant
+            assert event_payload["tenant"] == tenant
+    finally:
+        await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_event_stream_background_executor() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.get("/batch")
+    async def batch(stream: EventStream) -> EventStream:
+        def compute() -> list[dict[str, str]]:
+            return [{"message": "from-thread"}]
+
+        stream.fork(compute, mode=ExecutionMode.THREAD)
+        await stream.join_background()
+        await stream.close()
+        return stream
+
+    await app.startup()
+    try:
+        response = await app.dispatch("GET", "/batch", host="acme.demo.example.com")
+        assert response.stream is not None
+        chunks: list[bytes] = []
+        async for chunk in response.stream:
+            chunks.append(chunk)
+        payload = b"".join(chunks).decode()
+        data_lines = [line[len("data: ") :] for line in payload.splitlines() if line.startswith("data: ")]
+        assert data_lines
+        event_payload = json.loads(data_lines[-1])
+        assert event_payload == {"message": "from-thread"}
+    finally:
+        await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_event_stream_auto_return_on_none() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.get("/auto")
+    async def auto(stream: EventStream) -> None:
+        await stream.send("auto")
+        await stream.close()
+
+    await app.startup()
+    try:
+        response = await app.dispatch("GET", "/auto", host="acme.demo.example.com")
+    finally:
+        await app.shutdown()
+
+    assert response.stream is not None
+    chunks = [chunk async for chunk in response.stream]
+    payload = b"".join(chunks).decode()
+    assert "data: auto" in payload
+
+
+@pytest.mark.asyncio
+async def test_event_stream_primitives() -> None:
+    stream = EventStream()
+    assert not stream.closed
+
+    async def async_producer() -> None:
+        await asyncio.sleep(0)
+        await stream.send("async")
+
+    stream.fork(async_producer)
+
+    def threaded_payload() -> list[object]:
+        return [
+            "threaded",
+            b"binary",
+            {"value": 42},
+            ServerSentEvent(data="event", event="note"),
+            7,
+        ]
+
+    with pytest.raises(TypeError):
+        stream.fork(lambda: 1)
+    stream.fork(threaded_payload, mode=ExecutionMode.THREAD)
+    stream.fork(lambda: None, mode=ExecutionMode.THREAD)
+    await stream.send(ServerSentEvent(data={"gamma": True}, event_id="evt", retry=5, json=True))
+    await stream.send("alpha")
+    await stream.send(
+        ServerSentEvent(data="overridden", event="source", event_id="orig", retry=1),
+        event="manual",
+        event_id="explicit",
+        retry=9,
+    )
+    await stream.send("")
+    await stream.send("line\n")
+
+    response = stream.to_response(headers=(("x-test", "yes"),))
+    assert response.stream is not None
+    assert any(name == "content-type" and value == "text/event-stream" for name, value in response.headers)
+
+    await stream.join_background()
+    await stream.close()
+    await stream.close()
+
+    chunks: list[bytes] = []
+    async for chunk in response.stream:
+        chunks.append(chunk)
+    payload = b"".join(chunks).decode()
+    assert "data: async" in payload
+    assert "data: threaded" in payload
+    assert "data: binary" in payload
+    assert '"value":42' in payload
+    assert "event: note" in payload
+    assert "data: 7" in payload
+    assert "retry: 5" in payload
+    assert "event: manual" in payload
+    assert "id: explicit" in payload
+    assert "retry: 9" in payload
+    assert stream.closed
+
+    with pytest.raises(RuntimeError):
+        await stream.send("after")
+
+
+@pytest.mark.asyncio
+async def test_event_stream_background_cancellation() -> None:
+    stream = EventStream()
+
+    stalled = asyncio.Event()
+
+    async def wait_forever() -> None:
+        await stalled.wait()
+
+    task = stream.fork(wait_forever)
+    response = stream.to_response()
+    await stream.close()
+
+    collected: list[bytes] = []
+    assert response.stream is not None
+    async for chunk in response.stream:
+        collected.append(chunk)
+    assert collected == []
+    assert stream.closed
+    assert task.cancelled()
+    await stream.join_background()
+
+
+@pytest.mark.asyncio
+async def test_event_stream_multiple_stream_parameters_error() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.get("/multi")
+    async def multi(first: EventStream, second: EventStream) -> None:
+        return None
+
+    await app.startup()
+    try:
+        with pytest.raises(RuntimeError):
+            await app.dispatch("GET", "/multi", host="acme.demo.example.com")
+    finally:
+        await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_event_stream_empty_stream_asgi() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.get("/empty")
+    async def empty(stream: EventStream) -> EventStream:
+        await stream.close()
+        return stream
+
+    messages: list[dict[str, object]] = []
+
+    async def receive() -> Mapping[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app(
+            {
+                "type": "http",
+                "method": "GET",
+                "path": "/empty",
+                "query_string": b"",
+                "headers": [(b"host", b"acme.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    finally:
+        await app.shutdown()
+
+    assert messages[1]["more_body"] is False
+    assert messages[1]["body"] == b""
+
+
+@pytest.mark.asyncio
+async def test_send_response_body_handles_async_iterable() -> None:
+    class Wrapper:
+        def __aiter__(self):
+            async def generator():
+                yield b"chunk-one"
+                yield b"chunk-two"
+
+            return generator()
+
+    response = Response(stream=Wrapper())
+    messages: list[dict[str, object]] = []
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await _send_response_body(response, send)
+    assert messages[0]["more_body"] is True
+    assert messages[0]["body"] == b"chunk-one"
+    assert messages[1]["more_body"] is False
+    assert messages[1]["body"] == b"chunk-two"
+
+
+@pytest.mark.asyncio
+async def test_event_stream_log_task_error() -> None:
+    async def boom() -> None:
+        raise RuntimeError("boom")
+
+    task = asyncio.create_task(boom())
+    with pytest.raises(RuntimeError):
+        await task
+    _log_event_task_error(task)
+
+
+def test_event_stream_ensure_awaitable_type_error() -> None:
+    with pytest.raises(TypeError):
+        _ensure_event_awaitable("nope")

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,0 +1,756 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import cast
+
+import pytest
+
+from artemis.application import ArtemisApp, _status_to_websocket_close
+from artemis.config import AppConfig
+from artemis.exceptions import HTTPError
+from artemis.execution import ExecutionMode, TaskExecutor
+from artemis.http import Status
+from artemis.requests import Request
+from artemis.routing import RouteGuard
+from artemis.tenancy import TenantContext, TenantScope
+from artemis.websockets import WebSocket, WebSocketDisconnect
+from artemis.websockets import _log_task_error as _log_ws_task_error
+
+
+class RouteHelper:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_websocket_echo_and_background() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.websocket("/ws/{channel}")
+    async def ws(channel: str, socket: WebSocket) -> None:
+        await socket.accept()
+        message = await socket.receive_text()
+        await socket.send_text(f"{channel}:{message}")
+
+        async def background() -> None:
+            await asyncio.sleep(0)
+            await socket.send_json({"tenant": socket.request.tenant.tenant})
+
+        socket.fork(background)
+        await socket.join_background()
+        await socket.close()
+
+    messages: list[Mapping[str, object]] = []
+    incoming = [
+        {"type": "websocket.connect"},
+        {"type": "websocket.receive", "text": "ping"},
+    ]
+
+    async def receive() -> Mapping[str, object]:
+        if incoming:
+            return incoming.pop(0)
+        return {"type": "websocket.disconnect", "code": 1000}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "path": "/ws/chat",
+                "query_string": b"",
+                "headers": [(b"host", b"acme.demo.example.com")],
+                "subprotocols": [],
+            },
+            receive,
+            send,
+        )
+    finally:
+        await app.shutdown()
+
+    assert any(msg.get("type") == "websocket.accept" for msg in messages)
+    text_payloads = [msg.get("text") for msg in messages if msg.get("type") == "websocket.send"]
+    assert "chat:ping" in text_payloads
+    assert any("tenant" in str(payload) for payload in text_payloads)
+    assert any(msg.get("type") == "websocket.close" for msg in messages)
+
+
+@pytest.mark.asyncio
+async def test_websocket_executor_background() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.websocket("/worker")
+    async def worker(socket: WebSocket) -> None:
+        await socket.accept()
+
+        def produce() -> list[str]:
+            return ["background"]
+
+        socket.fork(produce, mode=ExecutionMode.THREAD)
+        await socket.join_background()
+        await socket.close()
+
+    messages: list[Mapping[str, object]] = []
+    incoming = [{"type": "websocket.connect"}]
+
+    async def receive() -> Mapping[str, object]:
+        if incoming:
+            return incoming.pop(0)
+        return {"type": "websocket.disconnect", "code": 1000}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "path": "/worker",
+                "query_string": b"",
+                "headers": [(b"host", b"beta.demo.example.com")],
+                "subprotocols": [],
+            },
+            receive,
+            send,
+        )
+    finally:
+        await app.shutdown()
+
+    sent_messages = [msg for msg in messages if msg.get("type") == "websocket.send"]
+    assert sent_messages and sent_messages[0].get("text") == "background"
+
+
+@pytest.mark.asyncio
+async def test_websocket_utility_methods() -> None:
+    sent: list[Mapping[str, object]] = []
+    incoming: list[Mapping[str, object]] = [
+        {"type": "websocket.receive", "bytes": bytearray(b"raw-data")},
+        {"type": "websocket.receive", "text": "hello"},
+        {"type": "websocket.receive", "text": '{"value": 1}'},
+        {"type": "websocket.receive", "bytes": b'{"value": 2}'},
+        {"type": "websocket.receive", "bytes": b"direct-bytes"},
+        {"type": "websocket.receive", "bytes": b"not-text"},
+        {"type": "websocket.receive", "text": "only-text"},
+        {"type": "websocket.disconnect", "code": 1001, "reason": "client closed"},
+    ]
+
+    async def receive() -> Mapping[str, object]:
+        return incoming.pop(0)
+
+    async def send(message: Mapping[str, object]) -> None:
+        sent.append(dict(message))
+
+    tenant = TenantContext(tenant="acme", site="demo", domain="example.com", scope=TenantScope.TENANT)
+    request = Request(
+        method="WEBSOCKET",
+        path="/ws",
+        headers={},
+        tenant=tenant,
+        path_params={},
+        query_string="",
+    )
+    executor = TaskExecutor()
+    default_disconnect = WebSocketDisconnect()
+    assert str(default_disconnect) == "WebSocket disconnected"
+    assert default_disconnect.code is None and default_disconnect.reason is None
+    socket = WebSocket(
+        scope={"type": "websocket", "subprotocols": ["json"]},
+        receive=receive,
+        send=send,
+        request=request,
+        executor=executor,
+    )
+
+    assert not socket.accepted
+    assert not socket.closed
+    await socket.accept(subprotocol="json", headers=(("x-test", "true"),))
+    await socket.accept()
+    assert socket.accepted
+    await socket._send_from_result(None)
+    await socket.send_bytes(memoryview(b"bytes"))
+    await socket.send_json({"payload": True})
+    assert await socket.receive_bytes() == b"raw-data"
+    assert await socket.receive_text() == "hello"
+    assert await socket.receive_json() == {"value": 1}
+    assert await socket.receive_json(type=dict) == {"value": 2}
+    assert await socket.receive_bytes() == b"direct-bytes"
+    with pytest.raises(TypeError):
+        await socket.receive_text()
+    with pytest.raises(TypeError):
+        await socket.receive_bytes()
+    dummy = asyncio.create_task(asyncio.sleep(0))
+    await dummy
+    socket._background.add(dummy)
+    await socket.close(code=1002, reason="closing")
+    await socket.wait_closed()
+    assert socket.closed
+    await socket.close()
+    with pytest.raises(WebSocketDisconnect) as exc:
+        await socket.receive()
+    disconnect = cast(WebSocketDisconnect, exc.value)
+    assert disconnect.code == 1001
+    assert disconnect.reason == "client closed"
+    with pytest.raises(RuntimeError):
+        await socket._ensure_open()
+    await executor.shutdown()
+
+    close_messages = [msg for msg in sent if msg.get("type") == "websocket.close"]
+    assert close_messages and close_messages[0].get("code") == 1002
+
+
+@pytest.mark.asyncio
+async def test_websocket_auto_accept_and_fork_behaviour() -> None:
+    sent: list[Mapping[str, object]] = []
+    incoming: list[Mapping[str, object]] = [
+        {"type": "websocket.disconnect", "code": 1000},
+    ]
+
+    async def receive() -> Mapping[str, object]:
+        return incoming.pop(0)
+
+    async def send(message: Mapping[str, object]) -> None:
+        sent.append(dict(message))
+
+    tenant = TenantContext(tenant="beta", site="demo", domain="example.com", scope=TenantScope.TENANT)
+    request = Request(method="WEBSOCKET", path="/auto", headers={}, tenant=tenant, path_params={}, query_string="")
+    socket = WebSocket(scope={"type": "websocket"}, receive=receive, send=send, request=request)
+
+    await socket.send_text("auto")
+    await socket._send_from_result(["extra", b"bytes", {"extra": True}, [1, 2]])
+    task = socket.fork(asyncio.sleep, 0)
+    await socket.join_background()
+    assert task.done()
+    with pytest.raises(TypeError):
+        socket.fork(lambda: 123)
+    with pytest.raises(RuntimeError):
+        socket.fork(lambda: "threaded", mode=ExecutionMode.THREAD)
+    blocker = asyncio.Event()
+
+    async def stalled() -> None:
+        await blocker.wait()
+
+    stalled_task = socket.fork(stalled)
+    await socket.close()
+    await socket.wait_closed()
+    assert stalled_task.cancelled()
+    with pytest.raises(WebSocketDisconnect) as exc:
+        await socket.receive()
+    cast(WebSocketDisconnect, exc.value)
+    assert any(msg.get("type") == "websocket.accept" for msg in sent)
+
+
+@pytest.mark.asyncio
+async def test_websocket_missing_host_closes() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+    messages: list[Mapping[str, object]] = []
+
+    async def receive() -> Mapping[str, object]:
+        return {"type": "websocket.connect"}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app({"type": "websocket", "path": "/ws", "headers": []}, receive, send)
+    finally:
+        await app.shutdown()
+
+    assert messages and messages[0]["code"] == 4400
+
+
+@pytest.mark.asyncio
+async def test_websocket_unknown_tenant_closes() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+    messages: list[Mapping[str, object]] = []
+
+    async def receive() -> Mapping[str, object]:
+        return {"type": "websocket.connect"}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "path": "/ws",
+                "headers": [(b"host", b"unknown.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    finally:
+        await app.shutdown()
+
+    assert messages and messages[0]["code"] == 4404
+
+
+@pytest.mark.asyncio
+async def test_websocket_route_not_found() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+    messages: list[Mapping[str, object]] = []
+
+    async def receive() -> Mapping[str, object]:
+        return {"type": "websocket.connect"}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "path": "/missing",
+                "headers": [(b"host", b"acme.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    finally:
+        await app.shutdown()
+
+    assert messages and messages[0]["code"] == 4404
+
+
+@pytest.mark.asyncio
+async def test_websocket_invalid_initial_message() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.websocket("/ws")
+    async def ws(socket: WebSocket) -> None:  # pragma: no cover - handshake should fail before execution
+        await socket.accept()
+        await socket.close()
+
+    messages: list[Mapping[str, object]] = []
+
+    async def receive() -> Mapping[str, object]:
+        return {"type": "websocket.receive"}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "path": "/ws",
+                "headers": [(b"host", b"acme.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    finally:
+        await app.shutdown()
+
+    assert messages and messages[0]["code"] == 4400
+
+
+@pytest.mark.asyncio
+async def test_websocket_authorization_failure_close() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    guard = RouteGuard(action="chat:open", resource_type="room")
+
+    @app.websocket("/guarded", authorize=guard)
+    async def guarded(socket: WebSocket) -> None:  # pragma: no cover - guard blocks execution
+        await socket.accept()
+
+    messages: list[Mapping[str, object]] = []
+
+    async def receive() -> Mapping[str, object]:
+        return {"type": "websocket.connect"}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "path": "/guarded",
+                "headers": [(b"host", b"acme.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    finally:
+        await app.shutdown()
+
+    assert messages and messages[0]["code"] == 4403
+
+
+@pytest.mark.asyncio
+async def test_websocket_handler_exception_closes() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.websocket("/boom")
+    async def boom(socket: WebSocket) -> None:
+        raise ValueError("boom")
+
+    messages: list[Mapping[str, object]] = []
+
+    async def receive() -> Mapping[str, object]:
+        return {"type": "websocket.connect"}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    with pytest.raises(ValueError):
+        await app(
+            {
+                "type": "websocket",
+                "path": "/boom",
+                "headers": [(b"host", b"acme.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    await app.shutdown()
+
+    assert messages and messages[0]["code"] == 1011
+
+
+@pytest.mark.asyncio
+async def test_websocket_handler_auto_close() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.websocket("/auto-close")
+    async def auto_close(socket: WebSocket) -> None:
+        await socket.accept()
+
+    messages: list[Mapping[str, object]] = []
+    incoming = [{"type": "websocket.connect"}]
+
+    async def receive() -> Mapping[str, object]:
+        if incoming:
+            return incoming.pop(0)
+        return {"type": "websocket.disconnect", "code": 1000}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "path": "/auto-close",
+                "headers": [(b"host", b"acme.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    finally:
+        await app.shutdown()
+
+    close_messages = [msg for msg in messages if msg.get("type") == "websocket.close"]
+    assert close_messages and close_messages[0]["code"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_websocket_handler_disconnect_propagation() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.websocket("/recv")
+    async def recv(socket: WebSocket) -> None:
+        await socket.accept()
+        await socket.receive()
+
+    messages: list[Mapping[str, object]] = []
+    incoming = [
+        {"type": "websocket.connect"},
+        {"type": "websocket.disconnect", "code": 1000},
+    ]
+
+    async def receive() -> Mapping[str, object]:
+        return incoming.pop(0)
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "path": "/recv",
+                "headers": [(b"host", b"acme.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    finally:
+        await app.shutdown()
+
+    assert any(msg.get("type") == "websocket.accept" for msg in messages)
+    assert not any(msg.get("type") == "websocket.close" for msg in messages)
+
+
+@pytest.mark.asyncio
+async def test_websocket_route_argument_injection() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    helper_value = RouteHelper()
+    app.dependencies.provide(RouteHelper, lambda: helper_value)
+
+    captured: dict[str, object] = {}
+
+    @app.websocket("/rooms/{room}/{room_id}")
+    def room_socket(  # type: ignore[return-type]
+        room,
+        room_id: int,
+        socket: WebSocket,
+        request: Request,
+        tenant: TenantContext,
+        helper: RouteHelper,
+    ) -> WebSocket:
+        asyncio.get_running_loop().create_task(socket.accept())
+        captured.update(
+            {
+                "room": room,
+                "room_id": room_id,
+                "path": request.path,
+                "tenant": tenant.tenant,
+                "helper": helper,
+            }
+        )
+        return socket
+
+    messages: list[Mapping[str, object]] = []
+    incoming = [{"type": "websocket.connect"}]
+
+    async def receive() -> Mapping[str, object]:
+        if incoming:
+            return incoming.pop(0)
+        return {"type": "websocket.disconnect", "code": 1000}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "path": "/rooms/main/5",
+                "headers": [(b"host", b"acme.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    finally:
+        await app.shutdown()
+
+    assert captured == {
+        "room": "main",
+        "room_id": 5,
+        "path": "/rooms/main/5",
+        "tenant": "acme",
+        "helper": helper_value,
+    }
+    assert any(msg.get("type") == "websocket.close" for msg in messages)
+
+
+@pytest.mark.asyncio
+async def test_websocket_handler_http_error_close() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.websocket("/http-error")
+    async def http_error(socket: WebSocket) -> None:
+        await socket.accept()
+        raise HTTPError(Status.FORBIDDEN, "blocked")
+
+    messages: list[Mapping[str, object]] = []
+    incoming = [{"type": "websocket.connect"}]
+
+    async def receive() -> Mapping[str, object]:
+        if incoming:
+            return incoming.pop(0)
+        return {"type": "websocket.disconnect", "code": 1000}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "path": "/http-error",
+                "headers": [(b"host", b"acme.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    finally:
+        await app.shutdown()
+
+    close_messages = [msg for msg in messages if msg.get("type") == "websocket.close"]
+    assert close_messages and close_messages[0]["code"] == 4403
+
+
+@pytest.mark.asyncio
+async def test_websocket_missing_dependency_closes() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.websocket("/missing-dependency")
+    async def missing_dependency(helper: RouteHelper, socket: WebSocket) -> None:
+        await socket.accept()
+
+    messages: list[Mapping[str, object]] = []
+    incoming = [{"type": "websocket.connect"}]
+
+    async def receive() -> Mapping[str, object]:
+        if incoming:
+            return incoming.pop(0)
+        return {"type": "websocket.disconnect", "code": 1000}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "path": "/missing-dependency",
+                "headers": [(b"host", b"acme.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    finally:
+        await app.shutdown()
+
+    close_messages = [msg for msg in messages if msg.get("type") == "websocket.close"]
+    assert close_messages and close_messages[0]["code"] == 1011
+
+
+@pytest.mark.asyncio
+async def test_websocket_disconnect_during_connect() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.websocket("/ws")
+    async def ws(socket: WebSocket) -> None:  # pragma: no cover - disconnect aborts handshake
+        await socket.accept()
+        await socket.close()
+
+    messages: list[Mapping[str, object]] = []
+
+    async def receive() -> Mapping[str, object]:
+        return {"type": "websocket.disconnect", "code": 1000}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "path": "/ws",
+                "headers": [(b"host", b"acme.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    finally:
+        await app.shutdown()
+
+    assert messages == []
+
+
+@pytest.mark.asyncio
+async def test_websocket_receive_exception_closes() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.websocket("/ws")
+    async def ws(socket: WebSocket) -> None:  # pragma: no cover - receive error aborts handshake
+        await socket.accept()
+        await socket.close()
+
+    messages: list[Mapping[str, object]] = []
+
+    async def receive() -> Mapping[str, object]:
+        raise RuntimeError("read failure")
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    with pytest.raises(RuntimeError):
+        await app(
+            {
+                "type": "websocket",
+                "path": "/ws",
+                "headers": [(b"host", b"acme.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    await app.shutdown()
+
+    assert messages and messages[0]["code"] == 1011
+
+
+@pytest.mark.asyncio
+async def test_websocket_handler_return_value_error() -> None:
+    app = ArtemisApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+
+    @app.websocket("/invalid")
+    async def invalid(socket: WebSocket) -> str:
+        await socket.accept()
+        return "not allowed"
+
+    messages: list[Mapping[str, object]] = []
+
+    async def receive() -> Mapping[str, object]:
+        return {"type": "websocket.connect"}
+
+    async def send(message: Mapping[str, object]) -> None:
+        messages.append(dict(message))
+
+    await app.startup()
+    with pytest.raises(RuntimeError):
+        await app(
+            {
+                "type": "websocket",
+                "path": "/invalid",
+                "headers": [(b"host", b"acme.demo.example.com")],
+            },
+            receive,
+            send,
+        )
+    await app.shutdown()
+
+    close_messages = [msg for msg in messages if msg.get("type") == "websocket.close"]
+    assert close_messages and close_messages[0]["code"] == 1011
+
+
+def test_status_to_websocket_close_mappings() -> None:
+    assert _status_to_websocket_close(400) == 4400
+    assert _status_to_websocket_close(401) == 4401
+    assert _status_to_websocket_close(404) == 4404
+    assert _status_to_websocket_close(409) == 4400
+    assert _status_to_websocket_close(500) == 1011
+    assert _status_to_websocket_close(200) == 1008
+
+
+@pytest.mark.asyncio
+async def test_websocket_log_task_error() -> None:
+    async def boom() -> None:
+        raise RuntimeError("boom")
+
+    task = asyncio.create_task(boom())
+    with pytest.raises(RuntimeError):
+        await task
+    _log_ws_task_error(task)


### PR DESCRIPTION
## Summary
- add an EventStream helper for server-sent events and wire it into the response pipeline
- introduce a WebSocket utility with background task support and integrate it into ArtemisApp routing
- expand the ASGI layer and tests to cover streaming, SSE, and WebSocket workflows

## Testing
- `uv run ruff check`
- `uv run ty check`
- `uv run pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68d34cad5928832eb16d2564400a389f