### PR TITLE
Integrate cedarpy runtime for RBAC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "argon2-cffi>=23.1.0",
     "brotli>=1.1.0",
     "zstandard>=0.22.0",
+    "cedarpy>=4.1.0",
 ]
 
 [project.scripts]

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,4 +1,7 @@
 import datetime as dt
+import json
+
+import pytest
 
 import artemis.rbac as rbac_module
 from artemis.id57 import generate_id57
@@ -17,6 +20,7 @@ from artemis.rbac import (
     CedarPolicy,
     CedarReference,
     RoleBinding,
+    _condition_from_mapping,
     bindings_from_admin,
     bindings_from_users,
     build_engine,
@@ -130,6 +134,100 @@ def test_admin_rbac_policies_allow_and_deny() -> None:
 
     policies = engine.policies()
     assert policies[0].resource.identifier == "*"
+
+
+def test_build_engine_prefers_cedarpy_backend() -> None:
+    now = _now()
+    role_id = generate_id57()
+    admin_user = generate_id57()
+    role = Role(
+        id=role_id,
+        name="admin-reporting",
+        scope=RoleScope.ADMIN,
+        tenant=None,
+        description=None,
+        created_at=now,
+        updated_at=now,
+    )
+    permission = Permission(
+        id=generate_id57(),
+        role_id=role_id,
+        action="reports:view",
+        resource_type="reports",
+        effect=PermissionEffect.ALLOW,
+        condition={"context_equals": {"tenant": "acme"}},
+        created_at=now,
+        updated_at=now,
+    )
+    assignment = AdminRoleAssignment(
+        id=generate_id57(),
+        admin_user_id=admin_user,
+        role_id=role_id,
+        assigned_at=now,
+    )
+
+    engine = build_engine(
+        roles=[role],
+        permissions=[permission],
+        bindings=bindings_from_admin([assignment]),
+    )
+    principal = CedarEntity(type="AdminUser", id=str(admin_user), attributes={"tenant": "acme"})
+    resource = CedarEntity(type="reports", id="*")
+    assert engine.uses_cedarpy() is True
+    assert (
+        engine.check(
+            principal=principal,
+            action="reports:view",
+            resource=resource,
+            context={"tenant": "acme"},
+        )
+        is True
+    )
+
+
+def test_cedar_runtime_schema_exposes_context() -> None:
+    now = _now()
+    role_id = generate_id57()
+    admin_user = generate_id57()
+    role = Role(
+        id=role_id,
+        name="admin-analytics",
+        scope=RoleScope.ADMIN,
+        tenant=None,
+        description=None,
+        created_at=now,
+        updated_at=now,
+    )
+    permission = Permission(
+        id=generate_id57(),
+        role_id=role_id,
+        action="analytics:view",
+        resource_type="analytics",
+        effect=PermissionEffect.ALLOW,
+        condition={"context_equals": {"tenant": "acme"}, "principal_attr_equals": {"tier": "gold"}},
+        created_at=now,
+        updated_at=now,
+    )
+    assignment = AdminRoleAssignment(
+        id=generate_id57(),
+        admin_user_id=admin_user,
+        role_id=role_id,
+        assigned_at=now,
+    )
+
+    engine = build_engine(
+        roles=[role],
+        permissions=[permission],
+        bindings=bindings_from_admin([assignment]),
+    )
+    runtime = getattr(engine, "_cedar_runtime")
+    assert runtime is not None
+    schema = json.loads(runtime._schema_json)
+    action_schema = schema[""]["actions"]["analytics:view"]
+    context_schema = action_schema["appliesTo"]["context"]["attributes"]
+    assert context_schema == {"tenant": {"type": "String", "required": False}}
+    principal_schema = schema[""]["entityTypes"]["AdminUser"]["shape"]["attributes"]
+    assert principal_schema["tier"] == {"type": "String", "required": False}
 
 
 def test_tenant_user_bindings_scope_resources() -> None:
@@ -393,7 +491,8 @@ def test_cedar_engine_supports_wildcard_principals_and_actions() -> None:
     assert engine.check(principal=principal, action="orders:delete", resource=resource, context=None) is True
 
 
-def test_cedar_engine_deduplicates_candidates() -> None:
+def test_cedar_engine_deduplicates_candidates(monkeypatch) -> None:
+    monkeypatch.setattr(rbac_module, "cedarpy", None)
     policy = CedarPolicy(
         effect=CedarEffect.ALLOW,
         principal=CedarReference("User", "user-1"),
@@ -406,6 +505,356 @@ def test_cedar_engine_deduplicates_candidates() -> None:
     assert engine.check(principal=principal, action="orders:read", resource=resource, context=None) is True
 
 
+def test_cedar_engine_returns_false_when_no_candidates(monkeypatch) -> None:
+    monkeypatch.setattr(rbac_module, "cedarpy", None)
+    policy = CedarPolicy(
+        effect=CedarEffect.ALLOW,
+        principal=CedarReference("User", "abc"),
+        actions=("orders:read",),
+        resource=CedarReference("orders", "*"),
+    )
+    engine = CedarEngine([policy])
+    principal = CedarEntity(type="User", id="abc")
+    resource = CedarEntity(type="orders", id="acme")
+    assert engine.check(principal=principal, action="orders:write", resource=resource, context=None) is False
+
+
+def test_cedar_engine_falls_back_for_manual_conditions() -> None:
+    policy = CedarPolicy(
+        effect=CedarEffect.ALLOW,
+        principal=CedarReference("User", "abc"),
+        actions=("noop",),
+        resource=CedarReference("resource", "*"),
+        condition=lambda _p, _a, _r, _c: True,
+    )
+    engine = CedarEngine([policy])
+    assert engine.uses_cedarpy() is False
+    principal = CedarEntity(type="User", id="abc")
+    resource = CedarEntity(type="resource", id="item")
+    assert engine.check(principal=principal, action="noop", resource=resource, context=None) is True
+
+
+def test_cedar_engine_handles_none_resource_via_fallback() -> None:
+    policy = CedarPolicy(
+        effect=CedarEffect.ALLOW,
+        principal=CedarReference("User", "abc"),
+        actions=("noop",),
+        resource=CedarReference("resource", "*"),
+    )
+    engine = CedarEngine([policy])
+    principal = CedarEntity(type="User", id="abc")
+    assert engine.uses_cedarpy() is True
+    assert engine.check(principal=principal, action="noop", resource=None, context=None) is True
+
+
+def test_cedar_runtime_build_skips_when_module_missing(monkeypatch) -> None:
+    monkeypatch.setattr(rbac_module, "cedarpy", None)
+    policy = CedarPolicy(
+        effect=CedarEffect.ALLOW,
+        principal=CedarReference("User", "abc"),
+        actions=("noop",),
+        resource=CedarReference("resource", "*"),
+    )
+    runtime = rbac_module._CedarPyRuntime.build([policy])
+    assert runtime is None
+
+
+def test_cedar_runtime_rejects_wildcard_resource() -> None:
+    wildcard_policy = CedarPolicy(
+        effect=CedarEffect.ALLOW,
+        principal=CedarReference("User", "abc"),
+        actions=("noop",),
+        resource=CedarReference("*", "*"),
+    )
+    engine = CedarEngine([wildcard_policy])
+    assert engine.uses_cedarpy() is False
+
+
+def test_python_condition_checks_context_and_principal(monkeypatch) -> None:
+    monkeypatch.setattr(rbac_module, "cedarpy", None)
+    policy = CedarPolicy(
+        effect=CedarEffect.ALLOW,
+        principal=CedarReference("User", "abc"),
+        actions=("noop",),
+        resource=CedarReference("resource", "*"),
+        condition=_condition_from_mapping(
+            {"context_equals": {"tenant": "acme"}, "principal_attr_equals": {"tier": "gold"}}
+        ),
+        condition_data={"context_equals": {"tenant": "acme"}, "principal_attr_equals": {"tier": "gold"}},
+    )
+    engine = CedarEngine([policy])
+    principal = CedarEntity(type="User", id="abc", attributes={"tier": "gold"})
+    assert engine.check(
+        principal=principal,
+        action="noop",
+        resource=CedarEntity(type="resource", id="any"),
+        context={"tenant": "acme"},
+    )
+    assert (
+        engine.check(
+            principal=principal,
+            action="noop",
+            resource=CedarEntity(type="resource", id="any"),
+            context={"tenant": "beta"},
+        )
+        is False
+    )
+
+
 def test_policy_action_keys_normalizes_wildcards() -> None:
     keys = rbac_module._policy_action_keys(["orders:read", "*", "orders:read"])
     assert keys == ("orders:read", None)
+
+
+def test_python_fallback_returns_false_on_deny(monkeypatch) -> None:
+    monkeypatch.setattr(rbac_module, "cedarpy", None)
+    principal = CedarEntity(type="User", id="abc")
+    resource = CedarEntity(type="orders", id="acme")
+    allow = CedarPolicy(
+        effect=CedarEffect.ALLOW,
+        principal=CedarReference("User", "abc"),
+        actions=("orders:read",),
+        resource=CedarReference("orders", "*"),
+    )
+    deny = CedarPolicy(
+        effect=CedarEffect.DENY,
+        principal=CedarReference("User", "abc"),
+        actions=("orders:read",),
+        resource=CedarReference("orders", "*"),
+    )
+    engine = CedarEngine([allow, deny])
+    assert engine.check(principal=principal, action="orders:read", resource=resource, context=None) is False
+
+
+def test_condition_from_mapping_handles_partial_sections() -> None:
+    gold = CedarEntity(type="User", id="abc", attributes={"tier": "gold"})
+    silver = CedarEntity(type="User", id="abc", attributes={"tier": "silver"})
+    only_principal = _condition_from_mapping({"principal_attr_equals": {"tier": "gold"}})
+    assert only_principal is not None
+    assert only_principal(gold, "noop", None, None) is True
+    assert only_principal(silver, "noop", None, None) is False
+    only_context = _condition_from_mapping({"context_equals": {"tenant": "acme"}})
+    assert only_context is not None
+    assert only_context(gold, "noop", None, {"tenant": "acme"}) is True
+    assert only_context(gold, "noop", None, None) is False
+
+
+def test_cedar_runtime_not_applicable_returns_false(monkeypatch) -> None:
+    class DummyResult:
+        def __init__(self, decision) -> None:
+            self.decision = decision
+
+    class DummyModule:
+        class Decision:
+            Allow = object()
+            Deny = object()
+            NotApplicable = object()
+
+        def __init__(self) -> None:
+            self.decision = self.Decision.NotApplicable
+
+        def is_authorized(self, **_kwargs):
+            return DummyResult(self.decision)
+
+    monkeypatch.setattr(rbac_module, "cedarpy", DummyModule())
+    policy = CedarPolicy(
+        effect=CedarEffect.ALLOW,
+        principal=CedarReference("User", "abc"),
+        actions=("orders:read",),
+        resource=CedarReference("orders", "acme"),
+    )
+    engine = CedarEngine([policy])
+    principal = CedarEntity(type="User", id="abc")
+    resource = CedarEntity(type="orders", id="acme")
+    assert engine.uses_cedarpy() is True
+    assert engine.check(principal=principal, action="orders:read", resource=resource, context=None) is False
+
+
+def test_cedar_runtime_rejects_policy_with_no_actions() -> None:
+    policy = CedarPolicy(
+        effect=CedarEffect.ALLOW,
+        principal=CedarReference("User", "abc"),
+        actions=(),
+        resource=CedarReference("orders", "acme"),
+    )
+    runtime = rbac_module._CedarPyRuntime.build([policy])
+    assert runtime is None
+
+
+def test_cedar_runtime_rejects_policy_with_wildcard_action() -> None:
+    policy = CedarPolicy(
+        effect=CedarEffect.ALLOW,
+        principal=CedarReference("User", "abc"),
+        actions=("*",),
+        resource=CedarReference("orders", "acme"),
+    )
+    runtime = rbac_module._CedarPyRuntime.build([policy])
+    assert runtime is None
+
+
+def test_cedar_policy_compiler_skips_wildcard_resources_in_schema() -> None:
+    compiler = rbac_module._CedarPolicyCompiler.__new__(rbac_module._CedarPolicyCompiler)
+    compiler._statements = ["permit(principal, action, resource);"]
+    compiler._entity_types = {}
+    compiler._context_attributes = {}
+    compiler._actions = {"noop": {"principalTypes": {"User"}, "resourceTypes": {"orders"}}}
+    compiler.supported = True
+    wildcard_policy = CedarPolicy(
+        effect=CedarEffect.ALLOW,
+        principal=CedarReference("User", "abc"),
+        actions=("noop",),
+        resource=CedarReference("*", "*"),
+    )
+    compiler._finalize([wildcard_policy])
+    schema = json.loads(compiler.schema_json)
+    assert "*" not in schema[""]["entityTypes"]
+
+
+def test_serialize_entity_skips_missing_attributes() -> None:
+    entity = CedarEntity(type="User", id="abc", attributes=None)
+    serialized = rbac_module._serialize_entity(entity, {"tier": "String"})
+    assert serialized["attrs"] == {}
+
+
+def test_serialize_entity_rejects_invalid_attribute_type() -> None:
+    entity = CedarEntity(type="User", id="abc", attributes={"tier": "gold"})
+    with pytest.raises(ValueError):
+        rbac_module._serialize_entity(entity, {"tier": "Boolean"})
+
+
+def test_render_condition_rejects_unsupported_context_values() -> None:
+    context_attributes: dict[str, dict[str, str]] = {}
+    principal_attributes: dict[str, dict[str, str]] = {}
+    result = rbac_module._render_condition(
+        lambda *_args: True,
+        {"context_equals": {"tenant": ["acme"]}},
+        action="orders:read",
+        principal_type="User",
+        principal_attributes=principal_attributes,
+        context_attributes=context_attributes,
+    )
+    assert result is None
+
+
+def test_render_condition_detects_conflicting_context_types() -> None:
+    context_attributes: dict[str, dict[str, str]] = {}
+    principal_attributes: dict[str, dict[str, str]] = {}
+    first = rbac_module._render_condition(
+        lambda *_args: True,
+        {"context_equals": {"tenant": "acme"}},
+        action="orders:read",
+        principal_type="User",
+        principal_attributes=principal_attributes,
+        context_attributes=context_attributes,
+    )
+    assert first is not None
+    conflict = rbac_module._render_condition(
+        lambda *_args: True,
+        {"context_equals": {"tenant": 1}},
+        action="orders:read",
+        principal_type="User",
+        principal_attributes=principal_attributes,
+        context_attributes=context_attributes,
+    )
+    assert conflict is None
+
+
+def test_render_condition_allows_repeated_context_types() -> None:
+    context_attributes: dict[str, dict[str, str]] = {}
+    principal_attributes: dict[str, dict[str, str]] = {}
+    first = rbac_module._render_condition(
+        lambda *_args: True,
+        {"context_equals": {"tenant": "acme"}},
+        action="orders:read",
+        principal_type="User",
+        principal_attributes=principal_attributes,
+        context_attributes=context_attributes,
+    )
+    assert first is not None
+    repeated = rbac_module._render_condition(
+        lambda *_args: True,
+        {"context_equals": {"tenant": "beta"}},
+        action="orders:read",
+        principal_type="User",
+        principal_attributes=principal_attributes,
+        context_attributes=context_attributes,
+    )
+    assert repeated is not None
+
+
+def test_render_condition_detects_conflicting_principal_types() -> None:
+    context_attributes: dict[str, dict[str, str]] = {}
+    principal_attributes: dict[str, dict[str, str]] = {}
+    first = rbac_module._render_condition(
+        lambda *_args: True,
+        {"principal_attr_equals": {"tier": "gold"}},
+        action="orders:read",
+        principal_type="User",
+        principal_attributes=principal_attributes,
+        context_attributes=context_attributes,
+    )
+    assert first is not None
+    conflict = rbac_module._render_condition(
+        lambda *_args: True,
+        {"principal_attr_equals": {"tier": True}},
+        action="orders:read",
+        principal_type="User",
+        principal_attributes=principal_attributes,
+        context_attributes=context_attributes,
+    )
+    assert conflict is None
+
+
+def test_render_condition_allows_repeated_principal_types() -> None:
+    context_attributes: dict[str, dict[str, str]] = {}
+    principal_attributes: dict[str, dict[str, str]] = {}
+    first = rbac_module._render_condition(
+        lambda *_args: True,
+        {"principal_attr_equals": {"tier": "gold"}},
+        action="orders:read",
+        principal_type="User",
+        principal_attributes=principal_attributes,
+        context_attributes=context_attributes,
+    )
+    assert first is not None
+    repeated = rbac_module._render_condition(
+        lambda *_args: True,
+        {"principal_attr_equals": {"tier": "silver"}},
+        action="orders:read",
+        principal_type="User",
+        principal_attributes=principal_attributes,
+        context_attributes=context_attributes,
+    )
+    assert repeated is not None
+
+
+def test_render_condition_rejects_unsupported_principal_values() -> None:
+    context_attributes: dict[str, dict[str, str]] = {}
+    principal_attributes: dict[str, dict[str, str]] = {}
+    result = rbac_module._render_condition(
+        lambda *_args: True,
+        {"principal_attr_equals": {"tier": ["gold"]}},
+        action="orders:read",
+        principal_type="User",
+        principal_attributes=principal_attributes,
+        context_attributes=context_attributes,
+    )
+    assert result is None
+
+
+def test_cedar_literal_and_type_helpers() -> None:
+    assert rbac_module._cedar_literal("acme") == '"acme"'
+    assert rbac_module._cedar_literal(True) == "true"
+    assert rbac_module._cedar_literal(10) == "10"
+    assert rbac_module._cedar_literal(1.2) is None
+    assert rbac_module._cedar_type_for_value("acme") == "String"
+    assert rbac_module._cedar_type_for_value(False) == "Boolean"
+    assert rbac_module._cedar_type_for_value(5) == "Long"
+    assert rbac_module._cedar_type_for_value(1.2) is None
+
+
+def test_cedar_attribute_value_conversions() -> None:
+    assert rbac_module._cedar_attribute_value("gold", "String") == "gold"
+    assert rbac_module._cedar_attribute_value(True, "Boolean") is True
+    assert rbac_module._cedar_attribute_value(5, "Long") == 5
+    assert rbac_module._cedar_attribute_value("oops", "Long") is None

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,7 @@ source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },
     { name = "brotli" },
+    { name = "cedarpy" },
     { name = "granian" },
     { name = "msgspec" },
     { name = "psqlpy" },
@@ -78,6 +79,7 @@ dev = [
 requires-dist = [
     { name = "argon2-cffi", specifier = ">=23.1.0" },
     { name = "brotli", specifier = ">=1.1.0" },
+    { name = "cedarpy", specifier = ">=4.1.0" },
     { name = "granian", specifier = ">=1.5.0" },
     { name = "msgspec", specifier = ">=0.18.6" },
     { name = "psqlpy", specifier = ">=0.11.0" },
@@ -148,6 +150,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/af/85/a94e5cfaa0ca449d8f91c3d6f78313ebf919a0dbd55a100c711c6e9655bc/Brotli-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:832436e59afb93e1836081a20f324cb185836c617659b07b129141a8426973c7", size = 2930206, upload-time = "2024-10-18T12:32:51.198Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f0/a61d9262cd01351df22e57ad7c34f66794709acab13f34be2675f45bf89d/Brotli-1.1.0-cp313-cp313-win32.whl", hash = "sha256:43395e90523f9c23a3d5bdf004733246fba087f2948f87ab28015f12359ca6a0", size = 333804, upload-time = "2024-10-18T12:32:52.661Z" },
     { url = "https://files.pythonhosted.org/packages/7e/c1/ec214e9c94000d1c1974ec67ced1c970c148aa6b8d8373066123fc3dbf06/Brotli-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:9011560a466d2eb3f5a6e4929cf4a09be405c64154e12df0dd72713f6500e32b", size = 358517, upload-time = "2024-10-18T12:32:54.066Z" },
+]
+
+[[package]]
+name = "cedarpy"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/ce/ca562febe717b32eba7f63b5814c6f32769470eaa7678171d74036a5fe38/cedarpy-4.1.0.tar.gz", hash = "sha256:2cb77dae1a43bef8863c87d7d6660a99f3cffd4a61ee59a040c2e650e083aff4", size = 42292, upload-time = "2024-12-26T20:49:49.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/74/2bd90ee8250b36ca5c5381551541556b21e8c82a35aea07340ac8838bca3/cedarpy-4.1.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:09f886e5f1cbb1629b5e59882ddf515f9adae8b0371b9ea1c0fa07d85b1a4733", size = 3612792, upload-time = "2024-12-26T20:49:42.252Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/89/c5388338bcc8e536d3651d16df04f09f549e8184b41b186e40e2e75a1f60/cedarpy-4.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:795df19b904bb0d0f0af0489abba047e56a7a4e4d227df0e874bd56d1f90820d", size = 3479477, upload-time = "2024-12-26T20:49:36.66Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5a/434764946e2a476c09a367074bd78d89219a5e9ef42109f9596c554cad99/cedarpy-4.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e9d59fbbc13b12e88e095a0c10affcc760b24b133789da5f2145f4c4a137383", size = 3871126, upload-time = "2024-12-26T20:49:01.738Z" },
+    { url = "https://files.pythonhosted.org/packages/52/53/cc97b2612e4bb79b883bee3c5f43d00c682265b4c593a7bb6b1542ecb348/cedarpy-4.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:132b25261d0dba8a8882098df5747f7bbeb96495d511e2900f68514f90a76fe5", size = 3933355, upload-time = "2024-12-26T20:49:22.069Z" },
+    { url = "https://files.pythonhosted.org/packages/30/20/7d4acb7224ba53a3dc42c00787d693f5ec5c4e08bb10ae43815581836b70/cedarpy-4.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:f9ebc76f475c1a50c7a1e8ac5734c83abc95cb2efa6c8ef29cabff68a5a51ef6", size = 3311804, upload-time = "2024-12-26T20:49:54.225Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/49/fa8fe3b5a466fae075d23468f1e09ac92926caea6a28aff60ad2f9d826d2/cedarpy-4.1.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:545751da78a5be60e3da30f18989bab50ccf9ec198f0ba3bddcc5366a834783b", size = 3611020, upload-time = "2024-12-26T20:49:44.632Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/20/1743e7192e02c18302b9212edfdbe425c6a292e9f78b1a22435fb85b5f96/cedarpy-4.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9688367f7de110aafc808be39ed6b19f70c9d3b3c9abe157019b07e057fc93ee", size = 3478735, upload-time = "2024-12-26T20:49:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/fc/313361a74a0eda83ddc5c1f830c3a30dfc4c0cf939994e48ee8868e0878a/cedarpy-4.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a401dc67f27feed2eed96a44dd699dda909f53cde6e953d215a635389608df4", size = 3872139, upload-time = "2024-12-26T20:49:06.736Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/38280d9d0b09b88db882d98401a67661be8a55aff29c4a18f56b2df68376/cedarpy-4.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:beb1154abb406ac9e6aae86912addd4e252a3f0ae9b49465bd1dd62272b4725a", size = 3933463, upload-time = "2024-12-26T20:49:26.965Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/65/cfa31d00d311018057f0f989a2010c6eb6b6bf8a87a3024cb6a8e82620df/cedarpy-4.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:9ac6d3e1b66d074641a4b972c00a8aacda12f245b95125b5f9ad3fbe5079d40c", size = 3313980, upload-time = "2024-12-26T20:49:56.027Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1e/8730e1d29355f070ecd79026b1a4f61852e2d8da6dd5fa6f428d2f3d546d/cedarpy-4.1.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:8f2fbff3c15654399d92018bde8b4efea486e778dd7009665870032399295086", size = 3611024, upload-time = "2024-12-26T20:49:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/fa/87a2f1ee7c5c93696c3d1d657323102a4c1e57e26fc608f60106ed11b055/cedarpy-4.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:63aae58b45b377b9e6e0562506c7d567bcef3fd25fa2bc801121c3f1d9d6791a", size = 3478735, upload-time = "2024-12-26T20:49:40.482Z" },
+    { url = "https://files.pythonhosted.org/packages/20/b5/22b0e74f61751b414e9ac1fb2fa4e607f6b3bd5b690fe0db226723670348/cedarpy-4.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ea2752a1713e2e788db782bebb3d0bc648abcaae57037d4e5d1151182f728a3", size = 3872139, upload-time = "2024-12-26T20:49:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/24/d8/785b4cfa4d076ae664be3a4df0471ec5140d5401900608bcb83880612724/cedarpy-4.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7900dd75e4933ab66e44d77e056ee736af163854c7a63ffea56113b1752cf55", size = 3933465, upload-time = "2024-12-26T20:49:28.652Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/11/c45a18ce46c7292a8775de5f102929a0e46c72ccb6375315fb977888b0a4/cedarpy-4.1.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ba0e58bd38780dafb4d1bf031ebc6cb8448285806b90d02c957523b218d6487", size = 3872144, upload-time = "2024-12-26T20:49:12.607Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add a cedarpy-backed runtime that compiles policies, schema, and entity payloads for `CedarEngine`
- extend RBAC helpers with condition metadata and serialization to feed the cedar runtime while preserving Python fallbacks
- add cedarpy as a dependency and expand RBAC tests to cover runtime, fallback, and helper edge cases

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3835c4e48832eb09389e6231bb3a0