### PR TITLE
Use rust-backed id57 package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "brotli>=1.1.0",
     "zstandard>=0.22.0",
     "cedarpy>=4.1.0",
+    "id57>=1.0.0",
 ]
 
 [project.scripts]

--- a/src/artemis/id57.py
+++ b/src/artemis/id57.py
@@ -1,89 +1,23 @@
-"""Utilities for generating lexicographically sortable ``id57`` identifiers."""
+"""Adapters for the Rust-backed ``id57`` helpers."""
 
 from __future__ import annotations
 
-import datetime as dt
-import uuid
-from dataclasses import dataclass
-from typing import Callable, Iterable
+import id57 as _id57
+
+ALPHABET = _id57.ALPHABET
+base57_encode = _id57.base57_encode
+decode57 = _id57.decode57
+generate_id57 = _id57.generate_id57
+
+USING_RUST_BACKEND = getattr(generate_id57, "__module__", "").startswith("id57._core")
+if not USING_RUST_BACKEND:  # pragma: no cover - runtime guard for unsupported platforms
+    msg = "Artemis requires the Rust-backed id57 extension; ensure the native wheel is available."
+    raise RuntimeError(msg)
 
 __all__ = [
     "ALPHABET",
-    "Id57Parts",
+    "USING_RUST_BACKEND",
     "base57_encode",
     "decode57",
     "generate_id57",
 ]
-
-
-# ``id57`` excludes characters that are commonly confused with one another.  The
-# alphabet is ordered from the smallest ASCII code point upward so that
-# lexicographical ordering matches numeric ordering when identifiers are padded.
-ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-_BASE = len(ALPHABET)
-
-
-@dataclass(slots=True, frozen=True)
-class Id57Parts:
-    """Composable parts used to construct a final ``id57`` value."""
-
-    value_factory: Callable[[dt.datetime, Callable[[], uuid.UUID], int], int]
-    pad_to: int
-
-    def render(self, *, timestamp: dt.datetime, uuid_factory: Callable[[], uuid.UUID], index: int) -> str:
-        return base57_encode(self.value_factory(timestamp, uuid_factory, index), pad_to=self.pad_to)
-
-
-def base57_encode(value: int, *, pad_to: int | None = None) -> str:
-    """Encode ``value`` as a base57 string using the ``id57`` alphabet."""
-
-    if value < 0:
-        raise ValueError("id57 only supports unsigned integers")
-    if value == 0:
-        encoded = ALPHABET[0]
-    else:
-        digits: list[str] = []
-        number = value
-        while number:
-            number, remainder = divmod(number, _BASE)
-            digits.append(ALPHABET[remainder])
-        encoded = "".join(reversed(digits))
-    if pad_to is not None and pad_to > len(encoded):
-        encoded = ALPHABET[0] * (pad_to - len(encoded)) + encoded
-    return encoded
-
-
-def decode57(value: str) -> int:
-    """Decode a base57 string back into an integer."""
-
-    number = 0
-    for char in value:
-        try:
-            digit = ALPHABET.index(char)
-        except ValueError as exc:  # pragma: no cover - defensive branch
-            raise ValueError(f"Character {char!r} is not valid for id57") from exc
-        number = number * _BASE + digit
-    return number
-
-
-def generate_id57(
-    *,
-    timestamp: dt.datetime | None = None,
-    random_source: Callable[[], uuid.UUID] | None = None,
-    parts: Iterable[Id57Parts] | None = None,
-) -> str:
-    """Generate a new lexicographically sortable identifier."""
-
-    ts = timestamp or dt.datetime.now(dt.UTC)
-    uuid_factory = random_source or uuid.uuid4
-    default_parts = (
-        Id57Parts(lambda ts, _uuid_factory, _idx: int(ts.timestamp() * 1_000_000), pad_to=11),
-        Id57Parts(lambda _ts, uuid_factory, _idx: uuid_factory().int, pad_to=22),
-    )
-    segments: list[str] = []
-    components = list(parts or default_parts)
-    if not components:
-        raise ValueError("id57 requires at least one component")
-    for index, component in enumerate(components):
-        segments.append(component.render(timestamp=ts, uuid_factory=uuid_factory, index=index))
-    return "".join(segments)

--- a/uv.lock
+++ b/uv.lock
@@ -58,6 +58,7 @@ dependencies = [
     { name = "brotli" },
     { name = "cedarpy" },
     { name = "granian" },
+    { name = "id57" },
     { name = "msgspec" },
     { name = "psqlpy" },
     { name = "rloop" },
@@ -81,6 +82,7 @@ requires-dist = [
     { name = "brotli", specifier = ">=1.1.0" },
     { name = "cedarpy", specifier = ">=4.1.0" },
     { name = "granian", specifier = ">=1.5.0" },
+    { name = "id57", specifier = ">=1.0.0" },
     { name = "msgspec", specifier = ">=0.18.6" },
     { name = "psqlpy", specifier = ">=0.11.0" },
     { name = "rloop", specifier = ">=0.2.0" },
@@ -431,6 +433,17 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/42/ecb762dbf7a1447a89b4884907d07fa505fd89f904c1e2d3bd4f30aeb9d1/granian-2.5.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:b78b8a6f30d0534b2db3f9cb99702d06be110b6e91f5639837a6f52f4891fc1d", size = 3172980, upload-time = "2025-09-18T11:51:59.428Z" },
     { url = "https://files.pythonhosted.org/packages/4c/2f/2abc969b206033d789c87d0ed7ee17a8831b0740e30590348abb544dba13/granian-2.5.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:10ae5ce26b1048888ac5aa3747415d8be8bbb014106b27ef0e77d23d2e00c51d", size = 3183479, upload-time = "2025-09-18T11:52:01.133Z" },
     { url = "https://files.pythonhosted.org/packages/2b/01/6fed17eab6232a19defdb42f5bd2fe51785e1de2e2086c78586ee1463898/granian-2.5.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:602fc22b2fde1c624cbc4ee64b0c8e547d394fbef70927ec7b0ca5e2d1ccea31", size = 2194686, upload-time = "2025-09-18T11:52:02.614Z" },
+]
+
+[[package]]
+name = "id57"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/56/20501da3ca6363321bc491e1f2bab2c1cb0957b470a26f42c7aac0671084/id57-1.0.0.tar.gz", hash = "sha256:b7e174f305a16b5b25d46a957e44f8b3ec5ef3e359448978e5ae94f851f7062d", size = 32334, upload-time = "2025-09-24T14:29:03.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/aa/e37c5c4bf5d68fb95ff019c44b7a8a8d6f1e09f9e63ea7e93895066d5c51/id57-1.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:35ecb58df4f08134211369b8fa5db0579d06c9e95f7f9d94590bec117593cac9", size = 202301, upload-time = "2025-09-24T14:29:18.632Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7a/fe7b07beb20afd2984f06e31823e8789ff23f3c5e8457621f5800a2c880d/id57-1.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:392f9436e8d2432ac1e6ea5c59609c6a2675d47a2827a5fff18d77974c88700c", size = 239294, upload-time = "2025-09-24T14:29:01.644Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/59/ed0593841b366d1a30789c6fa2454cbc91ff156bbb7524da3e6fbf748c85/id57-1.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:24644043f0e7f169a3f4d9ba81b45165b8c68e8e37b773023afa2aafa716353d", size = 138330, upload-time = "2025-09-24T14:30:44.635Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- depend on the rust-backed `id57` package and expose its helpers through `artemis.id57`
- add a runtime guard to require the native Rust backend for identifier generation
- update the ID57 tests to exercise the packaged API and assert the extension is loaded

## Testing
- uv run ruff check
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d40208e064832e84a2aa3064feb616