### PR TITLE
Add canonical support ticket models

### DIFF
--- a/src/artemis/http.py
+++ b/src/artemis/http.py
@@ -10,6 +10,7 @@ class Status(IntEnum):
     """Enumeration of the HTTP status codes used within the framework."""
 
     OK = 200
+    CREATED = 201
     NO_CONTENT = 204
     BAD_REQUEST = 400
     UNAUTHORIZED = 401

--- a/src/artemis/models.py
+++ b/src/artemis/models.py
@@ -51,6 +51,50 @@ class Subscription(DatabaseModel):
     current_period_end: dt.datetime
 
 
+class SupportTicketKind(str, Enum):
+    GENERAL = "general"
+    FEEDBACK = "feedback"
+    ISSUE = "issue"
+
+
+class SupportTicketStatus(str, Enum):
+    OPEN = "open"
+    RESPONDED = "responded"
+    RESOLVED = "resolved"
+
+
+class SupportTicketUpdate(msgspec.Struct, frozen=True):
+    """Immutable record describing an update applied to a support ticket."""
+
+    timestamp: dt.datetime
+    actor: str
+    note: str
+
+
+@model(scope=ModelScope.ADMIN, table="support_tickets")
+class SupportTicket(DatabaseModel):
+    """Support ticket raised by a tenant and tracked globally."""
+
+    tenant_slug: str
+    kind: SupportTicketKind
+    subject: str
+    message: str
+    status: SupportTicketStatus = SupportTicketStatus.OPEN
+    updates: tuple[SupportTicketUpdate, ...] = msgspec.field(default_factory=tuple)
+
+
+@model(scope=ModelScope.TENANT, table="support_tickets")
+class TenantSupportTicket(DatabaseModel):
+    """Tenant-scoped mirror of support tickets linked to the admin schema."""
+
+    admin_ticket_id: str
+    kind: SupportTicketKind
+    subject: str
+    message: str
+    status: SupportTicketStatus = SupportTicketStatus.OPEN
+    updates: tuple[SupportTicketUpdate, ...] = msgspec.field(default_factory=tuple)
+
+
 @model(
     scope=ModelScope.ADMIN,
     table="app_secrets",
@@ -380,11 +424,16 @@ __all__ = [
     "SessionToken",
     "Subscription",
     "SubscriptionStatus",
+    "SupportTicket",
+    "SupportTicketKind",
+    "SupportTicketStatus",
+    "SupportTicketUpdate",
     "TenantAuditLogEntry",
     "TenantFederatedUser",
     "TenantOidcProvider",
     "TenantSamlProvider",
     "TenantSecret",
+    "TenantSupportTicket",
     "TenantUser",
     "UserRole",
 ]

--- a/src/artemis/quickstart.py
+++ b/src/artemis/quickstart.py
@@ -6,9 +6,10 @@ import hashlib
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Final, Iterable, Mapping, Sequence, cast
+from typing import Any, Awaitable, Callable, Final, Iterable, Literal, Mapping, Sequence, cast
 
-from msgspec import Struct, convert, field, json
+import rure
+from msgspec import Struct, convert, field, json, to_builtins
 
 from .application import ArtemisApp
 from .authentication import (
@@ -19,11 +20,35 @@ from .authentication import (
     AuthenticationLoginRecord,
     LoginStep,
 )
+from .chatops import (
+    ChatMessage,
+    ChatOpsCommandBinding,
+    ChatOpsCommandContext,
+    ChatOpsCommandResolutionError,
+    ChatOpsConfig,
+    ChatOpsError,
+    ChatOpsInvocationError,
+    ChatOpsService,
+    ChatOpsSlashCommand,
+    SlackWebhookConfig,
+    parse_slash_command_args,
+)
 from .codegen import generate_typescript_client
 from .database import Database, _quote_identifier
+from .exceptions import HTTPError
+from .http import Status
 from .id57 import generate_id57
 from .migrations import Migration, MigrationRunner, MigrationScope, create_table_for_model
-from .models import SessionLevel
+from .models import (
+    BillingRecord,
+    BillingStatus,
+    SessionLevel,
+    SupportTicket,
+    SupportTicketKind,
+    SupportTicketStatus,
+    SupportTicketUpdate,
+    TenantSupportTicket,
+)
 from .openapi import generate_openapi
 from .orm import ORM, DatabaseModel, ModelScope, model
 from .requests import Request
@@ -33,6 +58,7 @@ from .tenancy import TenantContext, TenantScope
 _DEV_ENVIRONMENTS: Final[set[str]] = {"development", "dev", "local", "test"}
 _DEV_DOMAIN_SUFFIXES: Final[tuple[str, ...]] = (".local", ".localhost", ".test")
 _DEV_DOMAINS: Final[set[str]] = {"localhost", "127.0.0.1"}
+_TENANT_SLUG_PATTERN: Final[rure.Regex] = rure.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
 
 
 class QuickstartSsoProvider(Struct, frozen=True):
@@ -75,6 +101,94 @@ class QuickstartAdminRealm(Struct, frozen=True):
     """Administrative realm definition for the quickstart."""
 
     users: tuple[QuickstartUser, ...]
+
+
+class QuickstartChatOpsNotificationChannels(Struct, frozen=True):
+    """Channel overrides for ChatOps notifications."""
+
+    tenant_created: str | None = None
+    billing_updated: str | None = None
+    subscription_past_due: str | None = None
+    trial_extended: str | None = None
+    support_ticket_created: str | None = None
+    support_ticket_updated: str | None = None
+
+
+class QuickstartSlashCommand(Struct, frozen=True):
+    """ChatOps command metadata for the quickstart surface."""
+
+    name: str
+    action: Literal[
+        "create_tenant",
+        "extend_trial",
+        "tenant_metrics",
+        "system_diagnostics",
+        "ticket_update",
+    ]
+    description: str
+    visibility: Literal["admin", "public"] = "admin"
+    aliases: tuple[str, ...] = ()
+
+
+def _default_slash_commands() -> tuple[QuickstartSlashCommand, ...]:
+    return (
+        QuickstartSlashCommand(
+            name="create-tenant",
+            action="create_tenant",
+            description="Provision a new tenant from Slack.",
+            aliases=("quickstart-create-tenant",),
+        ),
+        QuickstartSlashCommand(
+            name="extend-trial",
+            action="extend_trial",
+            description="Extend a tenant's trial period from Slack.",
+            aliases=("quickstart-extend-trial",),
+        ),
+        QuickstartSlashCommand(
+            name="tenant-metrics",
+            action="tenant_metrics",
+            description="Summarize tenant metrics for administrators.",
+            aliases=("quickstart-tenant-metrics",),
+        ),
+        QuickstartSlashCommand(
+            name="system-diagnostics",
+            action="system_diagnostics",
+            description="Display quickstart diagnostics and health checks.",
+            aliases=("quickstart-system-diagnostics",),
+        ),
+        QuickstartSlashCommand(
+            name="ticket-update",
+            action="ticket_update",
+            description="Post an update to a customer support ticket.",
+            aliases=("quickstart-ticket-update",),
+        ),
+    )
+
+
+class QuickstartChatOpsSettings(Struct, frozen=True):
+    """Runtime ChatOps configuration maintained by the quickstart routes."""
+
+    enabled: bool = False
+    webhook: SlackWebhookConfig | None = None
+    notifications: QuickstartChatOpsNotificationChannels = field(
+        default_factory=QuickstartChatOpsNotificationChannels
+    )
+    slash_commands: tuple[QuickstartSlashCommand, ...] = field(
+        default_factory=_default_slash_commands
+    )
+    bot_user_id: str | None = None
+    admin_workspace: str | None = None
+
+
+class QuickstartSlashCommandInvocation(Struct, frozen=True):
+    """Payload delivered from ChatOps slash command integrations."""
+
+    text: str
+    user_id: str
+    command: str | None = None
+    user_name: str | None = None
+    channel_id: str | None = None
+    workspace_id: str | None = None
 
 
 QuickstartSession = AuthenticationFlowSession
@@ -126,6 +240,21 @@ class QuickstartTenantUserRecord(DatabaseModel):
     sso_provider: QuickstartSsoProvider | None = None
 
 
+@model(scope=ModelScope.ADMIN, table="quickstart_trial_extensions")
+class QuickstartTrialExtensionRecord(DatabaseModel):
+    """Audit record describing ChatOps-driven trial extensions."""
+
+    tenant_slug: str
+    extended_days: int
+    requested_by: str
+    note: str | None = None
+
+
+QuickstartSupportTicketUpdateLog = SupportTicketUpdate
+QuickstartSupportTicketRecord = SupportTicket
+QuickstartTenantSupportTicketRecord = TenantSupportTicket
+
+
 class QuickstartAuthConfig(Struct, frozen=True):
     """Configuration for the quickstart authentication engine."""
 
@@ -164,6 +293,41 @@ class MfaAttempt(Struct, frozen=True):
     code: str
 
 
+class BillingCreateRequest(Struct, frozen=True):
+    """Payload for creating a billing record via the quickstart routes."""
+
+    customer_id: str
+    plan_code: str
+    status: BillingStatus
+    amount_due_cents: int
+    currency: str
+    cycle_start: datetime
+    cycle_end: datetime
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class QuickstartTenantCreateRequest(Struct, frozen=True):
+    """Payload for creating a tenant through the quickstart API."""
+
+    slug: str
+    name: str
+
+
+class QuickstartSupportTicketRequest(Struct, frozen=True):
+    """Tenant-facing payload for creating a support ticket."""
+
+    subject: str
+    message: str
+    kind: Literal["general", "feedback", "issue"]
+
+
+class QuickstartSupportTicketUpdateRequest(Struct, frozen=True):
+    """Administrative payload for updating a support ticket."""
+
+    status: Literal["open", "responded", "resolved"]
+    note: str | None = None
+
+
 def quickstart_migrations() -> tuple[Migration, ...]:
     """Return the migrations required to persist quickstart data."""
 
@@ -172,15 +336,21 @@ def quickstart_migrations() -> tuple[Migration, ...]:
             name="quickstart_admin_tables",
             scope=MigrationScope.ADMIN,
             operations=(
+                create_table_for_model(BillingRecord),
                 create_table_for_model(QuickstartTenantRecord),
                 create_table_for_model(QuickstartAdminUserRecord),
                 create_table_for_model(QuickstartSeedStateRecord),
+                create_table_for_model(QuickstartTrialExtensionRecord),
+                create_table_for_model(SupportTicket),
             ),
         ),
         Migration(
             name="quickstart_tenant_tables",
             scope=MigrationScope.TENANT,
-            operations=(create_table_for_model(QuickstartTenantUserRecord),),
+            operations=(
+                create_table_for_model(QuickstartTenantUserRecord),
+                create_table_for_model(TenantSupportTicket),
+            ),
         ),
     )
 
@@ -513,6 +683,429 @@ def _default_auth_config() -> QuickstartAuthConfig:
 DEFAULT_QUICKSTART_AUTH: Final[QuickstartAuthConfig] = _default_auth_config()
 
 
+class QuickstartChatOpsControlPlane:
+    """Centralizes ChatOps configuration, normalization, and invocation handling."""
+
+    def __init__(
+        self,
+        app: ArtemisApp,
+        settings: QuickstartChatOpsSettings,
+        *,
+        command_pattern: rure.Regex,
+    ) -> None:
+        self._app = app
+        self._settings = settings
+        self._command_pattern = command_pattern
+        self._action_bindings: dict[str, str] = {}
+        self._binding_actions: dict[str, str] = {}
+
+    @property
+    def settings(self) -> QuickstartChatOpsSettings:
+        return self._settings
+
+    def register_action_binding(self, action: str, binding_name: str) -> None:
+        self._action_bindings[action] = binding_name
+
+    def configure(self, settings: QuickstartChatOpsSettings) -> None:
+        """Apply ``settings`` to the ChatOps service and command registry."""
+
+        normalized_commands = self.normalize_commands(settings.slash_commands or _default_slash_commands())
+        self._settings = QuickstartChatOpsSettings(
+            enabled=settings.enabled,
+            webhook=settings.webhook,
+            notifications=settings.notifications,
+            slash_commands=normalized_commands,
+            bot_user_id=settings.bot_user_id,
+            admin_workspace=settings.admin_workspace,
+        )
+        config = ChatOpsConfig(enabled=self._settings.enabled, default=self._settings.webhook)
+        self._app.chatops = ChatOpsService(config, observability=self._app.observability)
+        self._app.dependencies.provide(ChatOpsService, lambda: self._app.chatops)
+        self._apply_command_bindings()
+
+    def normalize_command_definition(self, command: QuickstartSlashCommand) -> QuickstartSlashCommand:
+        normalized_name = self._app.chatops.normalize_command_token(command.name)
+        if not normalized_name or not self._command_pattern.is_match(normalized_name):
+            raise HTTPError(Status.BAD_REQUEST, {"detail": "invalid_command_name"})
+        normalized_aliases: list[str] = []
+        seen_aliases = {normalized_name}
+        for alias in command.aliases:
+            normalized_alias = self._app.chatops.normalize_command_token(alias)
+            if not normalized_alias or not self._command_pattern.is_match(normalized_alias):
+                raise HTTPError(Status.BAD_REQUEST, {"detail": "invalid_command_name"})
+            if normalized_alias in seen_aliases:
+                continue
+            normalized_aliases.append(normalized_alias)
+            seen_aliases.add(normalized_alias)
+        return QuickstartSlashCommand(
+            name=normalized_name,
+            action=command.action,
+            description=command.description,
+            visibility=command.visibility,
+            aliases=tuple(normalized_aliases),
+        )
+
+    def normalize_commands(
+        self, commands: Iterable[QuickstartSlashCommand]
+    ) -> tuple[QuickstartSlashCommand, ...]:
+        normalized: list[QuickstartSlashCommand] = []
+        seen: set[str] = set()
+        for command in commands:
+            normalized_command = self.normalize_command_definition(command)
+            for token in (normalized_command.name, *normalized_command.aliases):
+                if token in seen:
+                    raise HTTPError(Status.BAD_REQUEST, {"detail": "duplicate_command"})
+                seen.add(token)
+            normalized.append(normalized_command)
+        return tuple(normalized)
+
+    def serialize_settings(self) -> dict[str, Any]:
+        payload = dict(to_builtins(self._settings))
+        if self._settings.admin_workspace is None:
+            payload["slash_commands"] = [
+                command
+                for command in payload.get("slash_commands", [])
+                if command.get("visibility") != "admin"
+            ]
+        return payload
+
+    def _apply_command_bindings(self) -> None:
+        for command in self._settings.slash_commands:
+            binding_name = self._action_bindings.get(command.action)
+            if not binding_name:
+                continue
+            try:
+                binding = self._app.chatops_commands.binding_by_name(binding_name)
+            except LookupError:
+                continue
+            updated_command = ChatOpsSlashCommand(
+                name=command.name,
+                description=command.description,
+                visibility=command.visibility,
+                aliases=command.aliases,
+            )
+            self._binding_actions[binding_name] = command.action
+            self._app.chatops_commands.register(
+                ChatOpsCommandBinding(
+                    command=updated_command,
+                    handler=binding.handler,
+                    name=binding.name,
+                )
+            )
+
+    def channel_for_event(self, event: str) -> str | None:
+        mapping = {
+            "tenant_created": self._settings.notifications.tenant_created,
+            "billing_updated": self._settings.notifications.billing_updated,
+            "subscription_past_due": self._settings.notifications.subscription_past_due,
+            "trial_extended": self._settings.notifications.trial_extended,
+            "support_ticket_created": self._settings.notifications.support_ticket_created,
+            "support_ticket_updated": self._settings.notifications.support_ticket_updated,
+        }
+        return mapping.get(event)
+
+    async def notify(
+        self,
+        event: str,
+        message: str,
+        *,
+        extra: Mapping[str, Any] | None = None,
+        channel: str | None = None,
+    ) -> None:
+        if not self._settings.enabled or self._settings.webhook is None:
+            return
+        destination = channel or self.channel_for_event(event)
+        builtins_extra = dict(to_builtins(extra or {}))
+        chat_message = ChatMessage(text=message, channel=destination, extra=builtins_extra)
+        admin_context = self._app.tenant_resolver.context_for(self._app.config.admin_subdomain, TenantScope.ADMIN)
+        try:
+            await self._app.chatops.send(admin_context, chat_message)
+        except ChatOpsError:
+            return
+
+    def resolve_invocation(
+        self,
+        request: Request,
+        payload: QuickstartSlashCommandInvocation,
+    ) -> tuple[ChatOpsCommandBinding, dict[str, str], str]:
+        command_name, arg_text = self._app.chatops.extract_command_from_invocation(
+            payload,
+            bot_user_id=self._settings.bot_user_id,
+        )
+        available_commands: list[ChatOpsSlashCommand] = []
+        for command in self._settings.slash_commands:
+            binding_name = self._action_bindings.get(command.action)
+            if not binding_name:
+                continue
+            try:
+                binding = self._app.chatops_commands.binding_by_name(binding_name)
+            except LookupError:
+                continue
+            available_commands.append(binding.command)
+        resolved_command = self._app.chatops.resolve_slash_command(
+            command_name,
+            available_commands,
+            tenant=request.tenant,
+            workspace_id=getattr(payload, "workspace_id", None),
+            admin_workspace=self._settings.admin_workspace,
+        )
+        binding = self._app.chatops_commands.binding_for(resolved_command)
+        args = parse_slash_command_args(arg_text)
+        actor = getattr(payload, "user_name", None) or getattr(payload, "user_id", "unknown")
+        return binding, args, actor
+
+    def action_for_binding(self, binding: ChatOpsCommandBinding) -> str | None:
+        return self._binding_actions.get(binding.name)
+
+
+class QuickstartAdminControlPlane:
+    """Encapsulates admin operations for the quickstart bundle."""
+
+    def __init__(
+        self,
+        app: ArtemisApp,
+        *,
+        slug_normalizer: Callable[[str], str],
+        slug_pattern: rure.Regex,
+        ensure_contexts: Callable[[Iterable[str]], Awaitable[None]],
+        chatops: QuickstartChatOpsControlPlane,
+        sync_allowed_tenants: Callable[[QuickstartAuthConfig], None],
+    ) -> None:
+        self._app = app
+        self._normalize_slug = slug_normalizer
+        self._slug_pattern = slug_pattern
+        self._ensure_contexts = ensure_contexts
+        self._chatops = chatops
+        self._sync_allowed_tenants = sync_allowed_tenants
+        self._reserved_slugs = {app.config.admin_subdomain, app.config.marketing_tenant}
+
+    async def create_tenant_from_inputs(
+        self,
+        slug: str,
+        name: str,
+        *,
+        orm: ORM,
+        engine: QuickstartAuthEngine,
+        actor: str,
+        source: str,
+    ) -> QuickstartTenantRecord:
+        normalized_slug = self._normalize_slug(slug)
+        cleaned_name = name.strip()
+        if not normalized_slug or not self._slug_pattern.is_match(normalized_slug):
+            raise HTTPError(Status.BAD_REQUEST, {"detail": "invalid_slug"})
+        if not cleaned_name:
+            raise HTTPError(Status.BAD_REQUEST, {"detail": "invalid_name"})
+        if normalized_slug in self._reserved_slugs:
+            raise HTTPError(409, {"detail": "slug_reserved"})
+        existing = await orm.admin.quickstart_tenants.get(filters={"slug": normalized_slug})
+        if existing is not None:
+            raise HTTPError(409, {"detail": "tenant_exists"})
+        await self._ensure_contexts([normalized_slug])
+        record = await orm.admin.quickstart_tenants.create(
+            {"slug": normalized_slug, "name": cleaned_name}
+        )
+        tenants_config = [tenant for tenant in engine.config.tenants if tenant.slug != normalized_slug]
+        tenants_config.append(QuickstartTenant(slug=normalized_slug, name=cleaned_name, users=()))
+        updated_config = QuickstartAuthConfig(
+            tenants=tuple(sorted(tenants_config, key=lambda item: item.slug)),
+            admin=engine.config.admin,
+            session_ttl_seconds=engine.config.session_ttl_seconds,
+            flow_ttl_seconds=engine.config.flow_ttl_seconds,
+            max_attempts=engine.config.max_attempts,
+        )
+        await engine.reload(updated_config)
+        self._sync_allowed_tenants(updated_config)
+        await self._chatops.notify(
+            "tenant_created",
+            f"Tenant '{cleaned_name}' ({normalized_slug}) provisioned via {source} by {actor}",
+            extra={
+                "slug": normalized_slug,
+                "name": cleaned_name,
+                "actor": actor,
+                "source": source,
+            },
+        )
+        return cast(QuickstartTenantRecord, record)
+
+    async def grant_trial_extension(
+        self,
+        tenant_slug: str,
+        days: int,
+        *,
+        note: str | None,
+        actor: str,
+        orm: ORM,
+    ) -> QuickstartTrialExtensionRecord:
+        normalized_slug = self._normalize_slug(tenant_slug)
+        if not normalized_slug or not self._slug_pattern.is_match(normalized_slug):
+            raise HTTPError(Status.BAD_REQUEST, {"detail": "invalid_slug"})
+        if days <= 0:
+            raise HTTPError(Status.BAD_REQUEST, {"detail": "invalid_days"})
+        tenant_record = await orm.admin.quickstart_tenants.get(filters={"slug": normalized_slug})
+        if tenant_record is None:
+            raise HTTPError(Status.NOT_FOUND, {"detail": "tenant_missing"})
+        note_value = note.strip() if note else None
+        record = QuickstartTrialExtensionRecord(
+            tenant_slug=normalized_slug,
+            extended_days=days,
+            requested_by=actor,
+            note=note_value,
+        )
+        created = await orm.admin.quickstart_trial_extensions.create(record)
+        await self._chatops.notify(
+            "trial_extended",
+            f"Trial for tenant '{normalized_slug}' extended by {days} days",
+            extra={
+                "tenant": normalized_slug,
+                "actor": actor,
+                "days": days,
+                "note": note_value,
+            },
+        )
+        return cast(QuickstartTrialExtensionRecord, created)
+
+    async def tenant_metrics(self, orm: ORM) -> dict[str, Any]:
+        tenants = await orm.admin.quickstart_tenants.list(order_by=("slug",))
+        trials = await orm.admin.quickstart_trial_extensions.list(order_by=("created_at",))
+        tickets = await orm.admin.support_tickets.list(order_by=("created_at",))
+        active_tenants = len(tenants)
+        trial_extensions = len(trials)
+        tickets_open = sum(1 for ticket in tickets if ticket.status != SupportTicketStatus.RESOLVED)
+        tickets_resolved = sum(1 for ticket in tickets if ticket.status == SupportTicketStatus.RESOLVED)
+        return {
+            "tenants": active_tenants,
+            "trial_extensions": trial_extensions,
+            "support_tickets": {
+                "open": tickets_open,
+                "resolved": tickets_resolved,
+                "total": len(tickets),
+            },
+        }
+
+    async def system_diagnostics(self, orm: ORM) -> dict[str, Any]:
+        tenants = await orm.admin.quickstart_tenants.list(order_by=("slug",))
+        tickets = await orm.admin.support_tickets.list(order_by=("created_at",))
+        return {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "tenants": [tenant.slug for tenant in tenants],
+            "chatops": {
+                "enabled": self._chatops.settings.enabled,
+                "configured": self._chatops.settings.webhook is not None,
+                "admin_workspace": self._chatops.settings.admin_workspace,
+            },
+            "support": {
+                "total": len(tickets),
+                "open": sum(
+                    1 for ticket in tickets if ticket.status != SupportTicketStatus.RESOLVED
+                ),
+            },
+            "allowed_tenants": sorted(self._app.tenant_resolver.allowed_tenants),
+        }
+
+    async def create_support_ticket(
+        self,
+        tenant: TenantContext,
+        payload: QuickstartSupportTicketRequest,
+        *,
+        orm: ORM,
+        actor: str,
+    ) -> QuickstartSupportTicketRecord:
+        subject = payload.subject.strip()
+        message = payload.message.strip()
+        if not subject or not message:
+            raise HTTPError(Status.BAD_REQUEST, {"detail": "invalid_ticket"})
+        ticket_kind = SupportTicketKind(payload.kind)
+        admin_record = QuickstartSupportTicketRecord(
+            tenant_slug=tenant.tenant,
+            kind=ticket_kind,
+            subject=subject,
+            message=message,
+        )
+        created = await orm.admin.support_tickets.create(admin_record)
+        tenant_record = QuickstartTenantSupportTicketRecord(
+            admin_ticket_id=created.id,
+            kind=ticket_kind,
+            subject=subject,
+            message=message,
+        )
+        await orm.tenants.support_tickets.create(tenant=tenant, model=tenant_record)
+        await self._chatops.notify(
+            "support_ticket_created",
+            f"Support ticket '{created.id}' opened by {tenant.tenant}",
+            extra={
+                "ticket_id": created.id,
+                "tenant": tenant.tenant,
+                "actor": actor,
+                "kind": ticket_kind.value,
+                "subject": subject,
+            },
+        )
+        return created
+
+    async def update_support_ticket(
+        self,
+        ticket_id: str,
+        payload: QuickstartSupportTicketUpdateRequest,
+        *,
+        orm: ORM,
+        actor: str,
+    ) -> QuickstartSupportTicketRecord:
+        record = await orm.admin.support_tickets.get(filters={"id": ticket_id})
+        if record is None:
+            raise HTTPError(Status.NOT_FOUND, {"detail": "ticket_missing"})
+        status = SupportTicketStatus(payload.status)
+        log_entries = list(record.updates)
+        if payload.note:
+            log_entries.append(
+                QuickstartSupportTicketUpdateLog(
+                    timestamp=datetime.now(timezone.utc),
+                    actor=actor,
+                    note=payload.note.strip(),
+                )
+            )
+        updated = await orm.admin.support_tickets.update(
+            filters={"id": ticket_id},
+            values={
+                "status": status,
+                "updates": tuple(log_entries),
+                "updated_by": actor,
+            },
+        )
+        tenant_context = self._app.tenant_resolver.context_for(record.tenant_slug, TenantScope.TENANT)
+        tenant_record = await orm.tenants.support_tickets.get(
+            tenant=tenant_context,
+            filters={"admin_ticket_id": ticket_id},
+        )
+        if tenant_record is not None:
+            tenant_updates = list(tenant_record.updates)
+            if payload.note:
+                tenant_updates.append(
+                    QuickstartSupportTicketUpdateLog(
+                        timestamp=datetime.now(timezone.utc),
+                        actor=actor,
+                        note=payload.note.strip(),
+                    )
+                )
+            await orm.tenants.support_tickets.update(
+                tenant=tenant_context,
+                filters={"admin_ticket_id": ticket_id},
+                values={
+                    "status": status,
+                    "updates": tuple(tenant_updates),
+                    "updated_by": actor,
+                },
+            )
+        await self._chatops.notify(
+            "support_ticket_updated",
+            f"Support ticket '{ticket_id}' updated by {actor}",
+            extra={
+                "ticket_id": ticket_id,
+                "status": status.value,
+                "actor": actor,
+                "note": payload.note,
+            },
+        )
+        return cast(QuickstartSupportTicketRecord, updated)
 def attach_quickstart(
     app: ArtemisApp,
     *,
@@ -543,6 +1136,27 @@ def attach_quickstart(
     passkey_path = f"{normalized}/auth/login/passkey" if normalized else "/auth/login/passkey"
     password_path = f"{normalized}/auth/login/password" if normalized else "/auth/login/password"
     mfa_path = f"{normalized}/auth/login/mfa" if normalized else "/auth/login/mfa"
+    billing_path = f"{normalized}/admin/billing" if normalized else "/admin/billing"
+    metrics_path = f"{normalized}/admin/metrics" if normalized else "/admin/metrics"
+    diagnostics_path = (
+        f"{normalized}/admin/diagnostics" if normalized else "/admin/diagnostics"
+    )
+    support_admin_path = (
+        f"{normalized}/admin/support/tickets"
+        if normalized
+        else "/admin/support/tickets"
+    )
+    support_admin_ticket_path = (
+        f"{support_admin_path}/{{ticket_id}}"
+    )
+    support_tenant_path = (
+        f"{normalized}/support/tickets" if normalized else "/support/tickets"
+    )
+    tenants_path = f"{normalized}/tenants" if normalized else "/tenants"
+    chatops_settings_path = (
+        f"{normalized}/admin/chatops" if normalized else "/admin/chatops"
+    )
+    chatops_slash_path = f"{normalized}/chatops/slash" if normalized else "/chatops/slash"
 
     env_auth_config = load_quickstart_auth_from_env()
     seed_hint = auth_config or env_auth_config or DEFAULT_QUICKSTART_AUTH
@@ -561,6 +1175,15 @@ def attach_quickstart(
     if app.database and app.orm:
         database = cast(Database, app.database)
         orm = cast(ORM, app.orm)
+        initial_chatops_config = app.chatops.config
+        initial_chatops_settings = QuickstartChatOpsSettings(
+            enabled=initial_chatops_config.enabled,
+            webhook=(
+                initial_chatops_config.default
+                if initial_chatops_config.enabled
+                else None
+            ),
+        )
         tenant_slugs = set(app.config.allowed_tenants)
         tenant_slugs.update(tenant.slug for tenant in seed_hint.tenants)
         tenant_slugs.discard(app.config.admin_subdomain)
@@ -625,6 +1248,365 @@ def attach_quickstart(
 
         app.on_startup(_bootstrap_quickstart)
 
+        def _require_admin(request: Request) -> None:
+            if request.tenant.scope is not TenantScope.ADMIN:
+                raise HTTPError(Status.FORBIDDEN, {"detail": "admin_required"})
+
+        def _normalize_slug(raw: str) -> str:
+            return raw.strip().lower()
+
+        chatops_control = QuickstartChatOpsControlPlane(
+            app,
+            initial_chatops_settings,
+            command_pattern=_TENANT_SLUG_PATTERN,
+        )
+        chatops_control.configure(initial_chatops_settings)
+
+        admin_control = QuickstartAdminControlPlane(
+            app,
+            slug_normalizer=_normalize_slug,
+            slug_pattern=_TENANT_SLUG_PATTERN,
+            ensure_contexts=_ensure_contexts_for,
+            chatops=chatops_control,
+            sync_allowed_tenants=_sync_allowed_tenants,
+        )
+
+        chatops_control.register_action_binding("create_tenant", "quickstart.chatops.create_tenant")
+        chatops_control.register_action_binding("extend_trial", "quickstart.chatops.extend_trial")
+        chatops_control.register_action_binding("tenant_metrics", "quickstart.chatops.tenant_metrics")
+        chatops_control.register_action_binding(
+            "system_diagnostics", "quickstart.chatops.system_diagnostics"
+        )
+        chatops_control.register_action_binding("ticket_update", "quickstart.chatops.ticket_update")
+
+        @app.chatops_command(
+            ChatOpsSlashCommand(
+                name="create-tenant",
+                description="Provision a new tenant from Slack.",
+                visibility="admin",
+                aliases=("quickstart-create-tenant",),
+            ),
+            name="quickstart.chatops.create_tenant",
+        )
+        async def quickstart_chatops_create_tenant_command(
+            context: ChatOpsCommandContext,
+        ) -> dict[str, Any]:
+            slug_arg = context.args.get("slug")
+            name_arg = context.args.get("name")
+            if not slug_arg or not name_arg:
+                raise HTTPError(Status.BAD_REQUEST, {"detail": "missing_arguments"})
+            orm = await context.dependencies.get(ORM)
+            engine = await context.dependencies.get(QuickstartAuthEngine)
+            record = await admin_control.create_tenant_from_inputs(
+                slug_arg,
+                name_arg,
+                orm=orm,
+                engine=engine,
+                actor=context.actor,
+                source="chatops",
+            )
+            return {
+                "status": "ok",
+                "action": "create_tenant",
+                "tenant": to_builtins(record),
+            }
+
+        @app.chatops_command(
+            ChatOpsSlashCommand(
+                name="extend-trial",
+                description="Extend a tenant's trial period from Slack.",
+                visibility="admin",
+                aliases=("quickstart-extend-trial",),
+            ),
+            name="quickstart.chatops.extend_trial",
+        )
+        async def quickstart_chatops_extend_trial_command(
+            context: ChatOpsCommandContext,
+        ) -> dict[str, Any]:
+            tenant_arg = context.args.get("tenant")
+            days_arg = context.args.get("days")
+            if not tenant_arg or not days_arg:
+                raise HTTPError(Status.BAD_REQUEST, {"detail": "missing_arguments"})
+            try:
+                days = int(days_arg)
+            except ValueError as exc:
+                raise HTTPError(Status.BAD_REQUEST, {"detail": "invalid_days"}) from exc
+            note_arg = context.args.get("note")
+            orm = await context.dependencies.get(ORM)
+            extension = await admin_control.grant_trial_extension(
+                tenant_arg,
+                days,
+                note=note_arg,
+                actor=context.actor,
+                orm=orm,
+            )
+            return {
+                "status": "ok",
+                "action": "extend_trial",
+                "extension": to_builtins(extension),
+            }
+
+        @app.chatops_command(
+            ChatOpsSlashCommand(
+                name="tenant-metrics",
+                description="Summarize tenant metrics for administrators.",
+                visibility="admin",
+                aliases=("quickstart-tenant-metrics",),
+            ),
+            name="quickstart.chatops.tenant_metrics",
+        )
+        async def quickstart_chatops_tenant_metrics_command(
+            context: ChatOpsCommandContext,
+        ) -> dict[str, Any]:
+            orm = await context.dependencies.get(ORM)
+            metrics = await admin_control.tenant_metrics(orm)
+            return {
+                "status": "ok",
+                "action": "tenant_metrics",
+                "metrics": metrics,
+            }
+
+        @app.chatops_command(
+            ChatOpsSlashCommand(
+                name="system-diagnostics",
+                description="Display quickstart diagnostics and health checks.",
+                visibility="admin",
+                aliases=("quickstart-system-diagnostics",),
+            ),
+            name="quickstart.chatops.system_diagnostics",
+        )
+        async def quickstart_chatops_system_diagnostics_command(
+            context: ChatOpsCommandContext,
+        ) -> dict[str, Any]:
+            orm = await context.dependencies.get(ORM)
+            diagnostics = await admin_control.system_diagnostics(orm)
+            return {
+                "status": "ok",
+                "action": "system_diagnostics",
+                "diagnostics": diagnostics,
+            }
+
+        @app.chatops_command(
+            ChatOpsSlashCommand(
+                name="ticket-update",
+                description="Post an update to a customer support ticket.",
+                visibility="admin",
+                aliases=("quickstart-ticket-update",),
+            ),
+            name="quickstart.chatops.ticket_update",
+        )
+        async def quickstart_chatops_ticket_update_command(
+            context: ChatOpsCommandContext,
+        ) -> dict[str, Any]:
+            ticket_id = context.args.get("ticket")
+            status_arg = context.args.get("status")
+            if not ticket_id or not status_arg:
+                raise HTTPError(Status.BAD_REQUEST, {"detail": "missing_arguments"})
+            if status_arg not in {"open", "responded", "resolved"}:
+                raise HTTPError(Status.BAD_REQUEST, {"detail": "invalid_status"})
+            update_payload = QuickstartSupportTicketUpdateRequest(
+                status=status_arg, note=context.args.get("note")
+            )
+            orm = await context.dependencies.get(ORM)
+            ticket = await admin_control.update_support_ticket(
+                ticket_id,
+                update_payload,
+                orm=orm,
+                actor=context.actor,
+            )
+            return {
+                "status": "ok",
+                "action": "ticket_update",
+                "ticket": to_builtins(ticket),
+            }
+
+
+        @app.get(billing_path, name="quickstart_admin_billing")
+        async def quickstart_admin_billing(request: Request, orm: ORM) -> Response:
+            _require_admin(request)
+            records = await orm.admin.billing.list(order_by=("created_at desc",))
+            return JSONResponse(tuple(to_builtins(record) for record in records))
+
+        @app.post(billing_path, name="quickstart_admin_create_billing")
+        async def quickstart_admin_create_billing(
+            request: Request,
+            payload: BillingCreateRequest,
+            orm: ORM,
+        ) -> Response:
+            _require_admin(request)
+            record = await orm.admin.billing.create(to_builtins(payload))
+            record_payload = to_builtins(record)
+            status_value = BillingStatus(record_payload.get("status", record.status))
+            await chatops_control.notify(
+                "billing_updated",
+                f"Billing updated for {record.customer_id} ({status_value.value})",
+                extra={
+                    "event": "billing_updated",
+                    **record_payload,
+                },
+            )
+            if status_value == BillingStatus.PAST_DUE:
+                await chatops_control.notify(
+                    "subscription_past_due",
+                    f"Subscription for {record.customer_id} is past due",
+                    extra={
+                        "event": "subscription_past_due",
+                        **record_payload,
+                    },
+                )
+            return JSONResponse(record_payload, status=201)
+
+        @app.get(metrics_path, name="quickstart_admin_metrics")
+        async def quickstart_admin_metrics(request: Request, orm: ORM) -> Response:
+            _require_admin(request)
+            metrics = await admin_control.tenant_metrics(orm)
+            return JSONResponse(metrics)
+
+        @app.get(diagnostics_path, name="quickstart_admin_diagnostics")
+        async def quickstart_admin_diagnostics(request: Request, orm: ORM) -> Response:
+            _require_admin(request)
+            diagnostics = await admin_control.system_diagnostics(orm)
+            return JSONResponse(diagnostics)
+
+        @app.get(support_admin_path, name="quickstart_admin_support_tickets")
+        async def quickstart_admin_support_tickets(request: Request, orm: ORM) -> Response:
+            _require_admin(request)
+            tickets = await orm.admin.support_tickets.list(order_by=("created_at desc",))
+            return JSONResponse(tuple(to_builtins(ticket) for ticket in tickets))
+
+        @app.post(
+            support_admin_ticket_path,
+            name="quickstart_admin_support_ticket_update",
+        )
+        async def quickstart_admin_support_ticket_update(
+            request: Request,
+            ticket_id: str,
+            payload: QuickstartSupportTicketUpdateRequest,
+            orm: ORM,
+        ) -> Response:
+            _require_admin(request)
+            updated = await admin_control.update_support_ticket(
+                ticket_id,
+                payload,
+                orm=orm,
+                actor=request.headers.get("x-artemis-actor", "quickstart-admin"),
+            )
+            return JSONResponse(to_builtins(updated))
+
+        @app.get(support_tenant_path, name="quickstart_tenant_support_tickets")
+        async def quickstart_tenant_support_tickets(request: Request, orm: ORM) -> Response:
+            if request.tenant.scope is TenantScope.ADMIN:
+                return JSONResponse(())
+            tickets = await orm.tenants.support_tickets.list(
+                tenant=request.tenant,
+                order_by=("created_at desc",),
+            )
+            return JSONResponse(tuple(to_builtins(ticket) for ticket in tickets))
+
+        @app.post(support_tenant_path, name="quickstart_tenant_create_support_ticket")
+        async def quickstart_tenant_create_support_ticket(
+            request: Request,
+            payload: QuickstartSupportTicketRequest,
+            orm: ORM,
+        ) -> Response:
+            if request.tenant.scope is not TenantScope.TENANT:
+                raise HTTPError(Status.FORBIDDEN, {"detail": "tenant_required"})
+            actor = request.headers.get("x-artemis-actor", request.tenant.tenant)
+            ticket = await admin_control.create_support_ticket(
+                request.tenant,
+                payload,
+                orm=orm,
+                actor=actor,
+            )
+            return JSONResponse(to_builtins(ticket), status=201)
+
+        @app.get(tenants_path, name="quickstart_tenants")
+        async def quickstart_list_tenants(request: Request, orm: ORM) -> Response:
+            if request.tenant.scope is TenantScope.ADMIN:
+                records = await orm.admin.quickstart_tenants.list(order_by=("slug",))
+            else:
+                record = await orm.admin.quickstart_tenants.get(
+                    filters={"slug": request.tenant.tenant}
+                )
+                records = [] if record is None else [record]
+            return JSONResponse(tuple(to_builtins(record) for record in records))
+
+        @app.post(tenants_path, name="quickstart_create_tenant")
+        async def quickstart_create_tenant(
+            request: Request,
+            payload: QuickstartTenantCreateRequest,
+            orm: ORM,
+            engine: QuickstartAuthEngine,
+        ) -> Response:
+            _require_admin(request)
+            actor = request.headers.get("x-artemis-actor", "quickstart-admin")
+            record = await admin_control.create_tenant_from_inputs(
+                payload.slug,
+                payload.name,
+                orm=orm,
+                engine=engine,
+                actor=actor,
+                source="api",
+            )
+            return JSONResponse(to_builtins(record), status=201)
+
+        @app.get(chatops_settings_path, name="quickstart_admin_chatops_settings")
+        async def quickstart_get_chatops_settings(request: Request) -> Response:
+            _require_admin(request)
+            return JSONResponse(chatops_control.serialize_settings())
+
+        @app.post(chatops_settings_path, name="quickstart_admin_update_chatops_settings")
+        async def quickstart_update_chatops_settings(
+            request: Request,
+            payload: QuickstartChatOpsSettings,
+        ) -> Response:
+            _require_admin(request)
+            if payload.enabled and payload.webhook is None:
+                raise HTTPError(Status.BAD_REQUEST, {"detail": "webhook_required"})
+            commands_iterable = payload.slash_commands or _default_slash_commands()
+            normalized_commands = chatops_control.normalize_commands(commands_iterable)
+            settings = QuickstartChatOpsSettings(
+                enabled=payload.enabled,
+                webhook=payload.webhook,
+                notifications=payload.notifications,
+                slash_commands=normalized_commands,
+                bot_user_id=payload.bot_user_id,
+                admin_workspace=payload.admin_workspace,
+            )
+            chatops_control.configure(settings)
+            return JSONResponse(chatops_control.serialize_settings())
+
+        @app.post(chatops_slash_path, name="quickstart_chatops_slash")
+        async def quickstart_chatops_slash(
+            request: Request,
+            payload: QuickstartSlashCommandInvocation,
+        ) -> Response:
+            try:
+                binding, args, actor = chatops_control.resolve_invocation(request, payload)
+            except ChatOpsInvocationError as exc:
+                detail = {"detail": exc.code}
+                status = Status.BAD_REQUEST
+                if exc.code == "invalid_bot_mention":
+                    status = Status.FORBIDDEN
+                raise HTTPError(status, detail) from exc
+            except ChatOpsCommandResolutionError as exc:
+                detail = {"detail": exc.code}
+                if exc.code == "unknown_command":
+                    raise HTTPError(Status.NOT_FOUND, detail) from exc
+                raise HTTPError(Status.FORBIDDEN, detail) from exc
+            scope = app.dependencies.scope(request)
+            context = ChatOpsCommandContext(
+                request=request,
+                payload=payload,
+                args=args,
+                actor=actor,
+                dependencies=scope,
+            )
+            result = await binding.handler(context)
+            if isinstance(result, Response):
+                return result
+            return JSONResponse(result)
+
     @app.get(ping_path, name="quickstart_ping")
     async def quickstart_ping() -> str:
         return "pong"
@@ -674,14 +1656,19 @@ def attach_quickstart(
 
 __all__ = [
     "DEFAULT_QUICKSTART_AUTH",
+    "BillingCreateRequest",
     "LoginStep",
     "MfaAttempt",
     "PasskeyAttempt",
     "PasswordAttempt",
+    "QuickstartAdminControlPlane",
     "QuickstartAdminRealm",
     "QuickstartAdminUserRecord",
     "QuickstartAuthConfig",
     "QuickstartAuthEngine",
+    "QuickstartChatOpsControlPlane",
+    "QuickstartChatOpsNotificationChannels",
+    "QuickstartChatOpsSettings",
     "QuickstartLoginResponse",
     "QuickstartPasskey",
     "QuickstartPasskeyRecord",
@@ -689,10 +1676,19 @@ __all__ = [
     "QuickstartSeedStateRecord",
     "QuickstartSeeder",
     "QuickstartSession",
+    "QuickstartSlashCommand",
+    "QuickstartSlashCommandInvocation",
     "QuickstartSsoProvider",
+    "QuickstartSupportTicketRecord",
+    "QuickstartSupportTicketRequest",
+    "QuickstartSupportTicketUpdateLog",
+    "QuickstartSupportTicketUpdateRequest",
     "QuickstartTenant",
+    "QuickstartTenantCreateRequest",
     "QuickstartTenantRecord",
+    "QuickstartTenantSupportTicketRecord",
     "QuickstartTenantUserRecord",
+    "QuickstartTrialExtensionRecord",
     "QuickstartUser",
     "attach_quickstart",
     "ensure_tenant_schemas",

--- a/src/artemis/quickstart.py
+++ b/src/artemis/quickstart.py
@@ -1581,6 +1581,10 @@ def attach_quickstart(
             request: Request,
             payload: QuickstartSlashCommandInvocation,
         ) -> Response:
+            settings = chatops_control.settings
+            if not settings.enabled or settings.webhook is None:
+                detail = "chatops_disabled" if not settings.enabled else "chatops_unconfigured"
+                raise HTTPError(Status.FORBIDDEN, {"detail": detail})
             try:
                 binding, args, actor = chatops_control.resolve_invocation(request, payload)
             except ChatOpsInvocationError as exc:

--- a/tests/test_chatops.py
+++ b/tests/test_chatops.py
@@ -23,7 +23,11 @@ from artemis import (
     TestClient,
 )
 from artemis.chatops import (
+    ChatOpsCommandResolutionError,
+    ChatOpsInvocationError,
+    ChatOpsSlashCommand,
     SlackWebhookClient,
+    parse_slash_command_args,
     _default_transport,
     _ensure_tls_destination,
     _maybe_await,
@@ -38,6 +42,48 @@ from tests.observability_stubs import (
     setup_stub_opentelemetry_without_status,
     setup_stub_sentry,
 )
+
+
+def test_chatops_parse_slash_command_args() -> None:
+    args = parse_slash_command_args('slug=alpha =ignored name="Alpha Beta" note=Trial flag extra="value" note2=" spaced "')
+    assert args == {
+        "slug": "alpha",
+        "name": "Alpha Beta",
+        "note": "Trial",
+        "extra": "value",
+        "note2": " spaced ",
+    }
+
+    fallback_args = parse_slash_command_args('slug=omega name="Alpha Beta note=Trial')
+    assert fallback_args == {
+        "slug": "omega",
+        "name": "Alpha",
+        "note": "Trial",
+    }
+
+
+def test_chatops_extract_command_from_invocation() -> None:
+    class Invocation:
+        def __init__(self, text: str, command: str | None = None) -> None:
+            self.text = text
+            self.command = command
+
+    service = ChatOpsService(ChatOpsConfig(enabled=True))
+    slash_payload = Invocation("/create-tenant slug=alpha name=Alpha", command="/create-tenant")
+    token, remaining = service.extract_command_from_invocation(slash_payload, bot_user_id="U999")
+    assert token == "create-tenant"
+    assert remaining == slash_payload.text
+
+    mention_payload = Invocation("<@U999> extend-trial slug=alpha days=30")
+    token, remaining = service.extract_command_from_invocation(mention_payload, bot_user_id="U999")
+    assert token == "extend-trial"
+    assert remaining == "slug=alpha days=30"
+
+    with pytest.raises(ChatOpsInvocationError):
+        service.extract_command_from_invocation(Invocation(""), bot_user_id="U999")
+
+    with pytest.raises(ChatOpsInvocationError):
+        service.extract_command_from_invocation(Invocation("<@U888> extend"), bot_user_id="U999")
 
 
 class RecordingTransport:
@@ -1002,3 +1048,86 @@ def test_ensure_tls_destination_allows_missing_base_host(monkeypatch: pytest.Mon
     config = SlackWebhookConfig(webhook_url="https:///missing")
 
     _ensure_tls_destination(DummyResponse(), config)
+
+
+def test_chatops_slash_command_resolution_rules() -> None:
+    config = ChatOpsConfig(
+        enabled=True,
+        default=SlackWebhookConfig(webhook_url="https://hooks.slack.com/services/default"),
+    )
+    service = ChatOpsService(config)
+    admin = TenantContext(tenant="admin", site="demo", domain="example.com", scope=TenantScope.ADMIN)
+    tenant = TenantContext(tenant="acme", site="demo", domain="example.com", scope=TenantScope.TENANT)
+    commands = [
+        ChatOpsSlashCommand(
+            name="create-tenant",
+            description="Create a tenant",
+            visibility="admin",
+            aliases=("quickstart-create-tenant",),
+        ),
+        ChatOpsSlashCommand(
+            name="extend-trial",
+            description="Extend a trial",
+            visibility="public",
+        ),
+    ]
+
+    assert service.normalize_command_token(" /Create-Tenant ") == "create-tenant"
+    resolved_admin = service.resolve_slash_command(
+        "/quickstart-create-tenant",
+        commands,
+        tenant=admin,
+        workspace_id="T123",
+        admin_workspace="T123",
+    )
+    assert resolved_admin is commands[0]
+
+    with pytest.raises(ChatOpsCommandResolutionError) as admin_scope_error:
+        service.resolve_slash_command(
+            "create-tenant",
+            commands,
+            tenant=tenant,
+            workspace_id="T123",
+            admin_workspace="T123",
+        )
+    assert admin_scope_error.value.code == "admin_command"
+
+    with pytest.raises(ChatOpsCommandResolutionError) as workspace_error:
+        service.resolve_slash_command(
+            "create-tenant",
+            commands,
+            tenant=admin,
+            workspace_id="T999",
+            admin_workspace="T123",
+        )
+    assert workspace_error.value.code == "workspace_forbidden"
+
+    resolved_public = service.resolve_slash_command(
+        "extend-trial",
+        commands,
+        tenant=tenant,
+        workspace_id="T123",
+        admin_workspace="T123",
+    )
+    assert resolved_public is commands[1]
+
+    with pytest.raises(ChatOpsCommandResolutionError) as unknown_error:
+        service.resolve_slash_command(
+            "unknown",
+            commands,
+            tenant=admin,
+            workspace_id="T123",
+            admin_workspace="T123",
+        )
+    assert unknown_error.value.code == "unknown_command"
+
+    disabled_service = ChatOpsService(ChatOpsConfig(enabled=True))
+    with pytest.raises(ChatOpsCommandResolutionError) as unconfigured_error:
+        disabled_service.resolve_slash_command(
+            "extend-trial",
+            commands,
+            tenant=tenant,
+            workspace_id="T123",
+            admin_workspace="T123",
+        )
+    assert unconfigured_error.value.code == "chatops_unconfigured"

--- a/tests/test_chatops.py
+++ b/tests/test_chatops.py
@@ -27,12 +27,12 @@ from artemis.chatops import (
     ChatOpsInvocationError,
     ChatOpsSlashCommand,
     SlackWebhookClient,
-    parse_slash_command_args,
     _default_transport,
     _ensure_tls_destination,
     _maybe_await,
     _validate_certificate_pin,
     _webhook_host,
+    parse_slash_command_args,
 )
 from artemis.serialization import json_decode
 from tests.observability_stubs import (
@@ -45,7 +45,9 @@ from tests.observability_stubs import (
 
 
 def test_chatops_parse_slash_command_args() -> None:
-    args = parse_slash_command_args('slug=alpha =ignored name="Alpha Beta" note=Trial flag extra="value" note2=" spaced "')
+    args = parse_slash_command_args(
+        'slug=alpha =ignored name="Alpha Beta" note=Trial flag extra="value" note2=" spaced "'
+    )
     assert args == {
         "slug": "alpha",
         "name": "Alpha Beta",
@@ -1090,6 +1092,7 @@ def test_chatops_slash_command_resolution_rules() -> None:
             workspace_id="T123",
             admin_workspace="T123",
         )
+    assert isinstance(admin_scope_error.value, ChatOpsCommandResolutionError)
     assert admin_scope_error.value.code == "admin_command"
 
     with pytest.raises(ChatOpsCommandResolutionError) as workspace_error:
@@ -1100,6 +1103,7 @@ def test_chatops_slash_command_resolution_rules() -> None:
             workspace_id="T999",
             admin_workspace="T123",
         )
+    assert isinstance(workspace_error.value, ChatOpsCommandResolutionError)
     assert workspace_error.value.code == "workspace_forbidden"
 
     resolved_public = service.resolve_slash_command(
@@ -1119,6 +1123,7 @@ def test_chatops_slash_command_resolution_rules() -> None:
             workspace_id="T123",
             admin_workspace="T123",
         )
+    assert isinstance(unknown_error.value, ChatOpsCommandResolutionError)
     assert unknown_error.value.code == "unknown_command"
 
     disabled_service = ChatOpsService(ChatOpsConfig(enabled=True))
@@ -1130,4 +1135,5 @@ def test_chatops_slash_command_resolution_rules() -> None:
             workspace_id="T123",
             admin_workspace="T123",
         )
+    assert isinstance(unconfigured_error.value, ChatOpsCommandResolutionError)
     assert unconfigured_error.value.code == "chatops_unconfigured"


### PR DESCRIPTION
## Summary
- add shared support ticket enums, update structs, and ORM models to the canonical models module
- wire the quickstart control plane through the canonical support ticket models, ensuring enums drive ChatOps notifications and tenant/admin metrics
- align quickstart tests with the canonical support ticket models, accessors, and enum-based assertions

## Testing
- uv run ruff check src/artemis/models.py src/artemis/quickstart.py tests/test_quickstart.py
- uv run pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d52129bf6c832eac863a208a5891a1