### PR TITLE
Add quickstart domain services and coverage tests

### DIFF
--- a/src/artemis/domain/__init__.py
+++ b/src/artemis/domain/__init__.py
@@ -1,0 +1,43 @@
+"""Domain service interfaces for Artemis quickstart integrations."""
+
+from .services import (
+    AuditLogEntry,
+    AuditLogExport,
+    AuditLogExportQuery,
+    AuditLogPage,
+    AuditService,
+    DelegationGrant,
+    DelegationRecord,
+    DelegationService,
+    PermissionSetCreate,
+    PermissionSetRecord,
+    RbacService,
+    RoleAssignment,
+    RoleAssignmentResult,
+    TileCreate,
+    TilePermissions,
+    TileRecord,
+    TileService,
+    TileUpdate,
+)
+
+__all__ = [
+    "AuditLogEntry",
+    "AuditLogExport",
+    "AuditLogExportQuery",
+    "AuditLogPage",
+    "AuditService",
+    "DelegationGrant",
+    "DelegationRecord",
+    "DelegationService",
+    "PermissionSetCreate",
+    "PermissionSetRecord",
+    "RbacService",
+    "RoleAssignment",
+    "RoleAssignmentResult",
+    "TileCreate",
+    "TilePermissions",
+    "TileRecord",
+    "TileService",
+    "TileUpdate",
+]

--- a/src/artemis/domain/quickstart_services.py
+++ b/src/artemis/domain/quickstart_services.py
@@ -1,0 +1,671 @@
+"""Concrete domain services powering the quickstart experience."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Callable, Sequence
+
+from msgspec import Struct, json, to_builtins
+
+from ..exceptions import HTTPError
+from ..http import Status
+from ..models import (
+    DashboardTile,
+    DashboardTilePermission,
+    Permission,
+    PermissionEffect,
+    Role,
+    RoleScope,
+    WorkspacePermissionDelegation,
+    WorkspacePermissionSet,
+    WorkspaceRoleAssignment,
+)
+from ..orm import ORM
+from ..rbac import CedarEffect, CedarEngine, CedarPolicy, CedarReference
+from ..tenancy import TenantContext, TenantScope
+from .services import (
+    AuditLogEntry,
+    AuditLogExport,
+    AuditLogExportQuery,
+    AuditLogPage,
+    AuditService,
+    DelegationGrant,
+    DelegationRecord,
+    DelegationService,
+    PermissionSetCreate,
+    PermissionSetRecord,
+    RbacService,
+    RoleAssignment,
+    RoleAssignmentResult,
+    TileCreate,
+    TilePermissions,
+    TileRecord,
+    TileService,
+    TileUpdate,
+)
+
+
+class _Clock(Struct, frozen=True):
+    now: Callable[[], datetime]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _tenant_for_workspace(current: TenantContext, workspace_id: str) -> TenantContext:
+    if current.scope is TenantScope.TENANT and current.tenant == workspace_id:
+        return current
+    return TenantContext(
+        tenant=workspace_id,
+        site=current.site,
+        domain=current.domain,
+        scope=TenantScope.TENANT,
+    )
+
+
+def _to_tile_record(
+    tile: DashboardTile,
+    permission: DashboardTilePermission | None,
+) -> TileRecord:
+    perms = None
+    if permission is not None:
+        perms = TilePermissions(roles=permission.roles, users=permission.users)
+    return TileRecord(
+        id=tile.id,
+        workspace_id=tile.workspace_id,
+        title=tile.title,
+        layout=tile.layout,
+        description=tile.description,
+        data_sources=tile.data_sources,
+        ai_insights_enabled=tile.ai_insights_enabled,
+        permissions=perms,
+        metadata=tile.metadata,
+    )
+
+
+class QuickstartTileService(TileService):
+    """Persist dashboard tiles using the ORM."""
+
+    def __init__(self, orm: ORM) -> None:
+        self._orm = orm
+
+    async def create_tile(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        principal,
+        payload: TileCreate,
+    ) -> TileRecord:
+        target = _tenant_for_workspace(tenant, workspace_id)
+        tile = await self._orm.tenants.dashboard_tiles.create(
+            DashboardTile(
+                workspace_id=workspace_id,
+                title=payload.title,
+                layout=dict(payload.layout),
+                description=payload.description,
+                data_sources=payload.data_sources,
+                ai_insights_enabled=payload.ai_insights_enabled,
+            ),
+            tenant=target,
+        )
+        return await self._load_tile(target, tile.id)
+
+    async def update_tile(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        tile_id: str,
+        principal,
+        payload: TileUpdate,
+    ) -> TileRecord:
+        target = _tenant_for_workspace(tenant, workspace_id)
+        values: dict[str, object] = {}
+        if payload.title is not None:
+            values["title"] = payload.title
+        if payload.layout is not None:
+            values["layout"] = dict(payload.layout)
+        if payload.description is not None:
+            values["description"] = payload.description
+        if payload.data_sources is not None:
+            values["data_sources"] = payload.data_sources
+        if payload.ai_insights_enabled is not None:
+            values["ai_insights_enabled"] = payload.ai_insights_enabled
+        if not values:
+            return await self._load_tile(target, tile_id)
+        updated = await self._orm.tenants.dashboard_tiles.update(
+            values,
+            tenant=target,
+            filters={"id": tile_id},
+        )
+        if not updated:
+            raise HTTPError(Status.NOT_FOUND, {"detail": "tile_missing"})
+        return await self._load_tile(target, tile_id)
+
+    async def delete_tile(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        tile_id: str,
+        principal,
+    ) -> None:
+        target = _tenant_for_workspace(tenant, workspace_id)
+        await self._orm.tenants.dashboard_tile_permissions.delete(
+            tenant=target,
+            filters={"tile_id": tile_id},
+        )
+        removed = await self._orm.tenants.dashboard_tiles.delete(
+            tenant=target,
+            filters={"id": tile_id},
+        )
+        if not removed:
+            raise HTTPError(Status.NOT_FOUND, {"detail": "tile_missing"})
+
+    async def set_permissions(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        tile_id: str,
+        principal,
+        permissions: TilePermissions,
+    ) -> TilePermissions:
+        target = _tenant_for_workspace(tenant, workspace_id)
+        existing = await self._orm.tenants.dashboard_tile_permissions.get(
+            tenant=target,
+            filters={"tile_id": tile_id},
+        )
+        payload = {
+            "roles": permissions.roles,
+            "users": permissions.users,
+        }
+        if existing is None:
+            await self._orm.tenants.dashboard_tile_permissions.create(
+                DashboardTilePermission(tile_id=tile_id, **payload),
+                tenant=target,
+            )
+        else:
+            await self._orm.tenants.dashboard_tile_permissions.update(
+                payload,
+                tenant=target,
+                filters={"id": existing.id},
+            )
+        return permissions
+
+    async def toggle_ai_insights(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        tile_id: str,
+        principal,
+        enabled: bool,
+    ) -> TileRecord:
+        target = _tenant_for_workspace(tenant, workspace_id)
+        updated = await self._orm.tenants.dashboard_tiles.update(
+            {"ai_insights_enabled": enabled},
+            tenant=target,
+            filters={"id": tile_id},
+        )
+        if not updated:
+            raise HTTPError(Status.NOT_FOUND, {"detail": "tile_missing"})
+        return await self._load_tile(target, tile_id)
+
+    async def _load_tile(self, tenant: TenantContext, tile_id: str) -> TileRecord:
+        tile = await self._orm.tenants.dashboard_tiles.get(
+            tenant=tenant,
+            filters={"id": tile_id},
+        )
+        if tile is None:
+            raise HTTPError(Status.NOT_FOUND, {"detail": "tile_missing"})
+        permission = await self._orm.tenants.dashboard_tile_permissions.get(
+            tenant=tenant,
+            filters={"tile_id": tile.id},
+        )
+        return _to_tile_record(tile, permission)
+
+
+class QuickstartRbacService(RbacService):
+    """Manage custom permission sets for workspaces."""
+
+    def __init__(self, orm: ORM, clock: Callable[[], datetime] | None = None) -> None:
+        self._orm = orm
+        self._clock = _Clock(now=clock or _utcnow)
+
+    async def create_permission_set(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        principal,
+        payload: PermissionSetCreate,
+    ) -> PermissionSetRecord:
+        target = _tenant_for_workspace(tenant, workspace_id)
+        existing = await self._orm.tenants.workspace_permission_sets.get(
+            tenant=target,
+            filters={"workspace_id": workspace_id, "name": payload.name},
+        )
+        if existing is not None:
+            raise HTTPError(409, {"detail": "permission_set_exists"})
+        normalized_scopes = tuple(dict.fromkeys(payload.permissions))
+        role = await self._orm.admin.roles.create(
+            Role(
+                name=f"{workspace_id}:{payload.name}",
+                scope=RoleScope.TENANT,
+                tenant=workspace_id,
+                description=payload.description,
+            )
+        )
+        for scope in normalized_scopes:
+            await self._orm.admin.permissions.create(
+                Permission(
+                    role_id=role.id,
+                    action=scope,
+                    resource_type="workspace",
+                    effect=PermissionEffect.ALLOW,
+                )
+            )
+        record = await self._orm.tenants.workspace_permission_sets.create(
+            WorkspacePermissionSet(
+                workspace_id=workspace_id,
+                name=payload.name,
+                permissions=normalized_scopes,
+                description=payload.description,
+                role_id=role.id,
+            ),
+            tenant=target,
+        )
+        return PermissionSetRecord(
+            id=record.id,
+            workspace_id=record.workspace_id,
+            name=record.name,
+            permissions=record.permissions,
+            role_id=record.role_id or role.id,
+            description=record.description,
+        )
+
+    async def assign_role(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        role_id: str,
+        principal,
+        payload: RoleAssignment,
+    ) -> RoleAssignmentResult:
+        target = _tenant_for_workspace(tenant, workspace_id)
+        permission_set = await self._orm.tenants.workspace_permission_sets.get(
+            tenant=target,
+            filters={"workspace_id": workspace_id, "role_id": role_id},
+        )
+        if permission_set is None:
+            raise HTTPError(Status.NOT_FOUND, {"detail": "permission_set_missing"})
+        now = self._clock.now()
+        assigned_ids: list[str] = []
+        for user_id in payload.user_ids:
+            existing = await self._orm.tenants.workspace_role_assignments.get(
+                tenant=target,
+                filters={"workspace_id": workspace_id, "role_id": role_id, "user_id": user_id},
+            )
+            if existing is not None:
+                assigned_ids.append(user_id)
+                continue
+            await self._orm.tenants.workspace_role_assignments.create(
+                WorkspaceRoleAssignment(
+                    workspace_id=workspace_id,
+                    role_id=role_id,
+                    user_id=user_id,
+                    assigned_at=now,
+                ),
+                tenant=target,
+            )
+            assigned_ids.append(user_id)
+        return RoleAssignmentResult(
+            role_id=role_id,
+            workspace_id=workspace_id,
+            assigned_user_ids=tuple(assigned_ids),
+        )
+
+
+class QuickstartDelegationService(DelegationService):
+    """Store delegations and expose effective permissions."""
+
+    def __init__(self, orm: ORM, clock: Callable[[], datetime] | None = None) -> None:
+        self._orm = orm
+        self._clock = _Clock(now=clock or _utcnow)
+
+    async def grant(
+        self,
+        *,
+        tenant: TenantContext,
+        principal,
+        payload: DelegationGrant,
+    ) -> DelegationRecord:
+        target = _tenant_for_workspace(tenant, payload.workspace_id)
+        if payload.starts_at >= payload.ends_at:
+            raise HTTPError(Status.BAD_REQUEST, {"detail": "invalid_window"})
+        grantor_scopes = set(
+            await self.resolve_effective_permissions(
+                tenant=target,
+                principal=principal,
+                user_id=payload.from_user_id,
+                workspace_id=payload.workspace_id,
+            )
+        )
+        missing = [scope for scope in payload.scopes if scope not in grantor_scopes]
+        if missing:
+            raise HTTPError(
+                Status.FORBIDDEN,
+                {"detail": "scope_not_granted", "scopes": missing},
+            )
+        manager = self._orm.tenants.permission_delegations
+        overlapping = await manager.list(
+            tenant=target,
+            filters={
+                "workspace_id": payload.workspace_id,
+                "from_user_id": payload.from_user_id,
+                "to_user_id": payload.to_user_id,
+            },
+        )
+        record: WorkspacePermissionDelegation | None = None
+        for candidate in overlapping:
+            if candidate.ends_at < payload.starts_at or candidate.starts_at > payload.ends_at:
+                continue
+            merged_scopes = tuple(sorted(set(candidate.scopes) | set(payload.scopes)))
+            new_start = min(candidate.starts_at, payload.starts_at)
+            new_end = max(candidate.ends_at, payload.ends_at)
+            updated = await manager.update(
+                {
+                    "scopes": merged_scopes,
+                    "starts_at": new_start,
+                    "ends_at": new_end,
+                },
+                tenant=target,
+                filters={"id": candidate.id},
+            )
+            record = updated[0]
+            break
+        if record is None:
+            created = await manager.create(
+                WorkspacePermissionDelegation(
+                    workspace_id=payload.workspace_id,
+                    from_user_id=payload.from_user_id,
+                    to_user_id=payload.to_user_id,
+                    scopes=tuple(sorted(set(payload.scopes))),
+                    starts_at=payload.starts_at,
+                    ends_at=payload.ends_at,
+                ),
+                tenant=target,
+            )
+            record = created
+        return self._to_record(record)
+
+    async def revoke(
+        self,
+        *,
+        tenant: TenantContext,
+        principal,
+        delegation_id: str,
+    ) -> None:
+        now = self._clock.now()
+        if tenant.scope is not TenantScope.TENANT:
+            raise HTTPError(Status.FORBIDDEN, {"detail": "tenant_required"})
+        updated = await self._orm.tenants.permission_delegations.update(
+            {"ends_at": now},
+            tenant=tenant,
+            filters={"id": delegation_id},
+        )
+        if not updated:
+            raise HTTPError(Status.NOT_FOUND, {"detail": "delegation_missing"})
+
+    async def list_active(
+        self,
+        *,
+        tenant: TenantContext,
+        principal,
+        user_id: str | None = None,
+        workspace_id: str | None = None,
+    ) -> Sequence[DelegationRecord]:
+        now = self._clock.now()
+        filters: dict[str, object] = {}
+        if workspace_id is not None:
+            filters["workspace_id"] = workspace_id
+        if user_id is not None:
+            filters["to_user_id"] = user_id
+        target = tenant if workspace_id is None else _tenant_for_workspace(tenant, workspace_id)
+        if target.scope is not TenantScope.TENANT:
+            raise HTTPError(Status.FORBIDDEN, {"detail": "tenant_required"})
+        entries = await self._orm.tenants.permission_delegations.list(
+            tenant=target,
+            filters=filters or None,
+        )
+        return tuple(
+            self._to_record(item)
+            for item in entries
+            if item.starts_at <= now <= item.ends_at
+        )
+
+    async def resolve_effective_permissions(
+        self,
+        *,
+        tenant: TenantContext,
+        principal,
+        user_id: str,
+        workspace_id: str | None = None,
+    ) -> tuple[str, ...]:
+        target = tenant if workspace_id is None else _tenant_for_workspace(tenant, workspace_id)
+        if target.scope is not TenantScope.TENANT:
+            raise HTTPError(Status.FORBIDDEN, {"detail": "tenant_required"})
+        sets = await self._orm.tenants.workspace_permission_sets.list(
+            tenant=target,
+            filters={"workspace_id": workspace_id} if workspace_id else None,
+        )
+        assignments = await self._orm.tenants.workspace_role_assignments.list(
+            tenant=target,
+            filters={"workspace_id": workspace_id, "user_id": user_id}
+            if workspace_id
+            else {"user_id": user_id},
+        )
+        permission_map = {record.role_id: record for record in sets}
+        scopes: set[str] = set()
+        for assignment in assignments:
+            record = permission_map.get(assignment.role_id)
+            if record is None:
+                continue
+            scopes.update(record.permissions)
+        now = self._clock.now()
+        delegations = await self._orm.tenants.permission_delegations.list(
+            tenant=target,
+            filters={"to_user_id": user_id},
+        )
+        for delegation in delegations:
+            if workspace_id is not None and delegation.workspace_id != workspace_id:
+                continue
+            if not (delegation.starts_at <= now <= delegation.ends_at):
+                continue
+            scopes.update(delegation.scopes)
+        return tuple(sorted(scopes))
+
+    @staticmethod
+    def _to_record(record: WorkspacePermissionDelegation) -> DelegationRecord:
+        return DelegationRecord(
+            id=record.id,
+            from_user_id=record.from_user_id,
+            to_user_id=record.to_user_id,
+            scopes=record.scopes,
+            workspace_id=record.workspace_id,
+            starts_at=record.starts_at,
+            ends_at=record.ends_at,
+            created_by=record.created_by or "system",
+        )
+
+
+class QuickstartAuditService(AuditService):
+    """Adapter that materializes audit data from tenant tables."""
+
+    def __init__(self, orm: ORM) -> None:
+        self._orm = orm
+
+    async def read(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        principal,
+        actor: str | None = None,
+        action: str | None = None,
+        entity: str | None = None,
+        from_time: datetime | None = None,
+        to_time: datetime | None = None,
+    ) -> AuditLogPage:
+        target = _tenant_for_workspace(tenant, workspace_id)
+        entries = await self._orm.tenants.audit_log.list(
+            tenant=target,
+            order_by=("created_at desc",),
+        )
+        filtered = [
+            entry
+            for entry in entries
+            if _matches(entry, actor=actor, action=action, entity=entity, from_time=from_time, to_time=to_time)
+        ]
+        return AuditLogPage(
+            entries=tuple(
+                AuditLogEntry(
+                    id=entry.id,
+                    timestamp=entry.created_at,
+                    actor=_audit_actor_label(entry.actor_id, entry.actor_type, tenant),
+                    action=entry.action,
+                    entity_type=entry.entity_type,
+                    entity_id=entry.entity_id,
+                    metadata=to_builtins(entry.metadata),
+                )
+                for entry in filtered
+            ),
+        )
+
+    async def export(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        principal,
+        query: AuditLogExportQuery,
+        actor: str | None = None,
+        action: str | None = None,
+        entity: str | None = None,
+        from_time: datetime | None = None,
+        to_time: datetime | None = None,
+    ) -> AuditLogExport:
+        page = await self.read(
+            tenant=tenant,
+            workspace_id=workspace_id,
+            principal=principal,
+            actor=actor,
+            action=action,
+            entity=entity,
+            from_time=from_time,
+            to_time=to_time,
+        )
+        if query.format == "csv":
+            header = "id,timestamp,actor,action,entity_type,entity_id\n"
+            rows = [
+                ",".join(
+                    (
+                        entry.id,
+                        entry.timestamp.isoformat(),
+                        entry.actor,
+                        entry.action,
+                        entry.entity_type,
+                        entry.entity_id or "",
+                    )
+                )
+                for entry in page.entries
+            ]
+            body = (header + "\n".join(rows)).encode("utf-8")
+            return AuditLogExport(
+                content_type="text/csv",
+                body=body,
+                filename=f"audit-{workspace_id}.csv",
+            )
+        return AuditLogExport(
+            content_type="application/json",
+            body=json.encode(to_builtins(page)),
+            filename=None,
+        )
+
+
+def _matches(
+    entry,
+    *,
+    actor: str | None,
+    action: str | None,
+    entity: str | None,
+    from_time: datetime | None,
+    to_time: datetime | None,
+) -> bool:
+    if actor and entry.actor_id != actor:
+        return False
+    if action and entry.action != action:
+        return False
+    if entity and entry.entity_type != entity:
+        return False
+    if from_time and entry.created_at < from_time:
+        return False
+    if to_time and entry.created_at > to_time:
+        return False
+    return True
+
+
+def _audit_actor_label(
+    actor_id: str | None,
+    actor_type: str | None,
+    tenant: TenantContext,
+) -> str:
+    if actor_type == "sysadmin":
+        return f"{tenant.site} {tenant.domain} sysadmin"
+    return actor_id or "unknown"
+
+
+async def build_cedar_engine(
+    orm: ORM,
+    *,
+    tenant: TenantContext,
+    at: datetime | None = None,
+) -> CedarEngine:
+    reference = at or _utcnow()
+    if tenant.scope is not TenantScope.TENANT:
+        raise HTTPError(Status.FORBIDDEN, {"detail": "tenant_required"})
+    permission_sets = await orm.tenants.workspace_permission_sets.list(tenant=tenant)
+    assignments = await orm.tenants.workspace_role_assignments.list(tenant=tenant)
+    delegations = await orm.tenants.permission_delegations.list(tenant=tenant)
+    sets_by_role = {record.role_id: record for record in permission_sets}
+    policies: list[CedarPolicy] = []
+    for assignment in assignments:
+        record = sets_by_role.get(assignment.role_id)
+        if record is None:
+            continue
+        for scope in record.permissions:
+            policies.append(
+                CedarPolicy(
+                    effect=CedarEffect.ALLOW,
+                    principal=CedarReference("User", assignment.user_id),
+                    actions=(scope,),
+                    resource=CedarReference("workspace", record.workspace_id),
+                )
+            )
+    for delegation in delegations:
+        if not (delegation.starts_at <= reference <= delegation.ends_at):
+            continue
+        for scope in delegation.scopes:
+            policies.append(
+                CedarPolicy(
+                    effect=CedarEffect.ALLOW,
+                    principal=CedarReference("User", delegation.to_user_id),
+                    actions=(scope,),
+                    resource=CedarReference("workspace", delegation.workspace_id),
+                )
+            )
+    return CedarEngine(policies)

--- a/src/artemis/domain/services.py
+++ b/src/artemis/domain/services.py
@@ -1,0 +1,287 @@
+"""Domain service contracts used by the quickstart transport layer."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Mapping, Protocol, Sequence
+
+import msgspec
+
+from ..rbac import CedarEntity
+from ..tenancy import TenantContext
+
+
+class TilePermissions(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Explicit access policy for a dashboard tile."""
+
+    roles: tuple[str, ...] = ()
+    users: tuple[str, ...] = ()
+
+
+class TileCreate(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Payload for creating a dashboard tile."""
+
+    title: str
+    layout: Mapping[str, object]
+    description: str | None = None
+    data_sources: tuple[str, ...] = ()
+    ai_insights_enabled: bool = False
+
+
+class TileUpdate(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Partial update payload for a dashboard tile."""
+
+    title: str | None = None
+    layout: Mapping[str, object] | None = None
+    description: str | None = None
+    data_sources: tuple[str, ...] | None = None
+    ai_insights_enabled: bool | None = None
+
+
+class TileRecord(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Canonical representation of a dashboard tile."""
+
+    id: str
+    workspace_id: str
+    title: str
+    layout: Mapping[str, object]
+    description: str | None = None
+    data_sources: tuple[str, ...] = ()
+    ai_insights_enabled: bool = False
+    permissions: TilePermissions | None = None
+    metadata: Mapping[str, object] | None = None
+
+
+class TileService(Protocol):
+    """Manage dashboard tiles while enforcing RBAC."""
+
+    async def create_tile(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        principal: CedarEntity | None,
+        payload: TileCreate,
+    ) -> TileRecord: ...
+
+    async def update_tile(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        tile_id: str,
+        principal: CedarEntity | None,
+        payload: TileUpdate,
+    ) -> TileRecord: ...
+
+    async def delete_tile(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        tile_id: str,
+        principal: CedarEntity | None,
+    ) -> None: ...
+
+    async def set_permissions(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        tile_id: str,
+        principal: CedarEntity | None,
+        permissions: TilePermissions,
+    ) -> TilePermissions: ...
+
+    async def toggle_ai_insights(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        tile_id: str,
+        principal: CedarEntity | None,
+        enabled: bool,
+    ) -> TileRecord: ...
+
+
+class PermissionSetCreate(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Definition for a custom permission set."""
+
+    name: str
+    permissions: tuple[str, ...]
+    description: str | None = None
+    create_role: bool = True
+
+
+class PermissionSetRecord(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Resolved permission set details."""
+
+    id: str
+    workspace_id: str
+    name: str
+    permissions: tuple[str, ...]
+    role_id: str
+    description: str | None = None
+
+
+class RoleAssignment(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Role assignment payload for workspace users."""
+
+    user_ids: tuple[str, ...] = msgspec.field(name="userIds", default_factory=tuple)
+
+
+class RoleAssignmentResult(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Outcome of assigning a role to a collection of users."""
+
+    role_id: str
+    workspace_id: str
+    assigned_user_ids: tuple[str, ...]
+
+
+class RbacService(Protocol):
+    """Manage workspace RBAC state (custom roles, permission sets)."""
+
+    async def create_permission_set(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        principal: CedarEntity | None,
+        payload: PermissionSetCreate,
+    ) -> PermissionSetRecord: ...
+
+    async def assign_role(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        role_id: str,
+        principal: CedarEntity | None,
+        payload: RoleAssignment,
+    ) -> RoleAssignmentResult: ...
+
+
+class DelegationGrant(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Request payload for granting time-bound permissions."""
+
+    from_user_id: str = msgspec.field(name="fromUserId")
+    to_user_id: str = msgspec.field(name="toUserId")
+    scopes: tuple[str, ...]
+    workspace_id: str = msgspec.field(name="workspaceId")
+    starts_at: datetime = msgspec.field(name="startsAt")
+    ends_at: datetime = msgspec.field(name="endsAt")
+
+
+class DelegationRecord(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Active delegation details."""
+
+    id: str
+    from_user_id: str
+    to_user_id: str
+    scopes: tuple[str, ...]
+    workspace_id: str = msgspec.field(name="workspaceId")
+    starts_at: datetime
+    ends_at: datetime
+    created_by: str
+
+
+class DelegationService(Protocol):
+    """Handle permission delegations across principals."""
+
+    async def grant(
+        self,
+        *,
+        tenant: TenantContext,
+        principal: CedarEntity | None,
+        payload: DelegationGrant,
+    ) -> DelegationRecord: ...
+
+    async def revoke(
+        self,
+        *,
+        tenant: TenantContext,
+        principal: CedarEntity | None,
+        delegation_id: str,
+    ) -> None: ...
+
+    async def list_active(
+        self,
+        *,
+        tenant: TenantContext,
+        principal: CedarEntity | None,
+        user_id: str | None = None,
+        workspace_id: str | None = None,
+    ) -> Sequence[DelegationRecord]: ...
+
+    async def resolve_effective_permissions(
+        self,
+        *,
+        tenant: TenantContext,
+        principal: CedarEntity | None,
+        user_id: str,
+        workspace_id: str | None = None,
+    ) -> tuple[str, ...]: ...
+
+
+class AuditLogEntry(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Serialized audit log entry."""
+
+    id: str
+    timestamp: datetime
+    actor: str
+    action: str
+    entity_type: str
+    entity_id: str | None = None
+    metadata: Mapping[str, object] = msgspec.field(default_factory=dict)
+
+
+class AuditLogPage(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Page of audit log entries with optional pagination cursor."""
+
+    entries: tuple[AuditLogEntry, ...]
+    next_token: str | None = None
+
+
+class AuditLogExportQuery(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Export configuration for audit log downloads."""
+
+    format: str = "json"
+
+
+class AuditLogExport(msgspec.Struct, frozen=True, omit_defaults=True):
+    """Exported audit log artifact."""
+
+    content_type: str
+    body: bytes
+    filename: str | None = None
+
+
+class AuditService(Protocol):
+    """Read and export audit information."""
+
+    async def read(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        principal: CedarEntity | None,
+        actor: str | None = None,
+        action: str | None = None,
+        entity: str | None = None,
+        from_time: datetime | None = None,
+        to_time: datetime | None = None,
+    ) -> AuditLogPage: ...
+
+    async def export(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        principal: CedarEntity | None,
+        query: AuditLogExportQuery,
+        actor: str | None = None,
+        action: str | None = None,
+        entity: str | None = None,
+        from_time: datetime | None = None,
+        to_time: datetime | None = None,
+    ) -> AuditLogExport: ...

--- a/src/artemis/http.py
+++ b/src/artemis/http.py
@@ -21,6 +21,7 @@ class Status(IntEnum):
     GONE = 410
     TOO_MANY_REQUESTS = 429
     INTERNAL_SERVER_ERROR = 500
+    NOT_IMPLEMENTED = 501
 
 
 def ensure_status(status: int | Status) -> int:

--- a/src/artemis/models.py
+++ b/src/artemis/models.py
@@ -95,6 +95,61 @@ class TenantSupportTicket(DatabaseModel):
     updates: tuple[SupportTicketUpdate, ...] = msgspec.field(default_factory=tuple)
 
 
+@model(scope=ModelScope.TENANT, table="dashboard_tiles")
+class DashboardTile(DatabaseModel):
+    """Dashboard tile persisted for a workspace."""
+
+    workspace_id: str
+    title: str
+    layout: dict[str, Any]
+    description: str | None = None
+    data_sources: tuple[str, ...] = msgspec.field(default_factory=tuple)
+    ai_insights_enabled: bool = False
+    metadata: dict[str, Any] = msgspec.field(default_factory=dict)
+
+
+@model(scope=ModelScope.TENANT, table="dashboard_tile_permissions")
+class DashboardTilePermission(DatabaseModel):
+    """Explicit permissions attached to a dashboard tile."""
+
+    tile_id: str
+    roles: tuple[str, ...] = msgspec.field(default_factory=tuple)
+    users: tuple[str, ...] = msgspec.field(default_factory=tuple)
+
+
+@model(scope=ModelScope.TENANT, table="workspace_permission_sets")
+class WorkspacePermissionSet(DatabaseModel):
+    """Custom permission sets defined within a workspace."""
+
+    workspace_id: str
+    name: str
+    permissions: tuple[str, ...] = msgspec.field(default_factory=tuple)
+    description: str | None = None
+    role_id: str | None = None
+
+
+@model(scope=ModelScope.TENANT, table="workspace_role_assignments")
+class WorkspaceRoleAssignment(DatabaseModel):
+    """Assignment of a workspace role to a single user."""
+
+    workspace_id: str
+    role_id: str
+    user_id: str
+    assigned_at: dt.datetime
+
+
+@model(scope=ModelScope.TENANT, table="permission_delegations")
+class WorkspacePermissionDelegation(DatabaseModel):
+    """Time-bound delegation between workspace principals."""
+
+    workspace_id: str
+    from_user_id: str
+    to_user_id: str
+    starts_at: dt.datetime
+    ends_at: dt.datetime
+    scopes: tuple[str, ...] = msgspec.field(default_factory=tuple)
+
+
 @model(
     scope=ModelScope.ADMIN,
     table="app_secrets",
@@ -436,4 +491,5 @@ __all__ = [
     "TenantSupportTicket",
     "TenantUser",
     "UserRole",
+    "WorkspacePermissionDelegation",
 ]

--- a/tests/test_quickstart_services.py
+++ b/tests/test_quickstart_services.py
@@ -1,0 +1,809 @@
+from __future__ import annotations
+
+import datetime as dt
+from collections import defaultdict
+from typing import Any, Iterable
+
+import pytest
+from msgspec import Struct, structs
+
+from artemis.domain.quickstart_services import (
+    QuickstartAuditService,
+    QuickstartDelegationService,
+    QuickstartRbacService,
+    QuickstartTileService,
+    build_cedar_engine,
+)
+from artemis.domain.services import (
+    AuditLogExportQuery,
+    DelegationGrant,
+    PermissionSetCreate,
+    RoleAssignment,
+    TileCreate,
+    TilePermissions,
+    TileUpdate,
+)
+from artemis.exceptions import HTTPError
+from artemis.models import (
+    DashboardTile,
+    DashboardTilePermission,
+    Permission,
+    Role,
+    WorkspacePermissionDelegation,
+    WorkspacePermissionSet,
+    WorkspaceRoleAssignment,
+)
+from artemis.rbac import CedarEntity, CedarReference
+from artemis.tenancy import TenantContext, TenantScope
+
+
+class InMemoryTable:
+    """Very small in-memory stand-in for :mod:`artemis.orm` model managers."""
+
+    def __init__(self, model_type: type[Any]) -> None:
+        self._model_type = model_type
+        self._storage: dict[str | None, list[Any]] = defaultdict(list)
+
+    def _bucket_key(self, tenant: TenantContext | None) -> str | None:
+        if tenant is None:
+            return None
+        return tenant.key()
+
+    def _matches(self, record: Any, filters: dict[str, object] | None) -> bool:
+        if not filters:
+            return True
+        for field, expected in filters.items():
+            if getattr(record, field) != expected:
+                return False
+        return True
+
+    async def create(self, data: Any, *, tenant: TenantContext | None = None) -> Any:
+        record = data if isinstance(data, self._model_type) else self._model_type(**data)
+        self._storage[self._bucket_key(tenant)].append(record)
+        return record
+
+    async def get(
+        self,
+        *,
+        tenant: TenantContext | None = None,
+        filters: dict[str, object] | None = None,
+    ) -> Any | None:
+        bucket = list(self._storage.get(self._bucket_key(tenant), ()))
+        for record in reversed(bucket):
+            if self._matches(record, filters):
+                return record
+        return None
+
+    async def list(
+        self,
+        *,
+        tenant: TenantContext | None = None,
+        filters: dict[str, object] | None = None,
+        order_by: Iterable[str] | None = None,
+        limit: int | None = None,
+    ) -> list[Any]:
+        bucket = [
+            record
+            for record in self._storage.get(self._bucket_key(tenant), ())
+            if self._matches(record, filters)
+        ]
+        if order_by:
+            field, *rest = next(iter(order_by)).split()
+            reverse = any(part.lower() == "desc" for part in rest)
+            bucket.sort(key=lambda item: getattr(item, field), reverse=reverse)
+        if limit is not None:
+            bucket = bucket[:limit]
+        return list(bucket)
+
+    async def update(
+        self,
+        values: dict[str, object],
+        *,
+        tenant: TenantContext | None = None,
+        filters: dict[str, object] | None = None,
+    ) -> list[Any]:
+        bucket_key = self._bucket_key(tenant)
+        bucket = self._storage.get(bucket_key, [])
+        updated: list[Any] = []
+        new_bucket: list[Any] = []
+        for record in bucket:
+            if self._matches(record, filters):
+                data = structs.asdict(record)
+                data.update(values)
+                new_record = self._model_type(**data)
+                updated.append(new_record)
+                new_bucket.append(new_record)
+            else:
+                new_bucket.append(record)
+        self._storage[bucket_key] = new_bucket
+        return updated
+
+    async def delete(
+        self,
+        *,
+        tenant: TenantContext | None = None,
+        filters: dict[str, object] | None = None,
+    ) -> int:
+        bucket_key = self._bucket_key(tenant)
+        bucket = self._storage.get(bucket_key, [])
+        kept: list[Any] = []
+        removed = 0
+        for record in bucket:
+            if self._matches(record, filters):
+                removed += 1
+            else:
+                kept.append(record)
+        self._storage[bucket_key] = kept
+        return removed
+
+
+class _Namespace:
+    def __init__(self, managers: dict[str, InMemoryTable]) -> None:
+        for name, manager in managers.items():
+            setattr(self, name, manager)
+
+
+class FakeORM:
+    def __init__(self, *, tenants: dict[str, InMemoryTable], admin: dict[str, InMemoryTable]) -> None:
+        self.tenants = _Namespace(tenants)
+        self.admin = _Namespace(admin)
+
+
+class AuditRow(Struct, kw_only=True, omit_defaults=True):
+    id: str
+    created_at: dt.datetime
+    actor_id: str | None
+    actor_type: str | None
+    action: str
+    entity_type: str
+    entity_id: str | None = None
+    metadata: dict[str, Any] = {}
+
+
+class TickingClock:
+    def __init__(self, initial: dt.datetime) -> None:
+        self.value = initial
+
+    def now(self) -> dt.datetime:
+        return self.value
+
+
+@pytest.fixture
+def tenant_alpha() -> TenantContext:
+    return TenantContext(tenant="alpha", site="demo", domain="local.test", scope=TenantScope.TENANT)
+
+
+@pytest.fixture
+def tenant_beta() -> TenantContext:
+    return TenantContext(tenant="beta", site="demo", domain="local.test", scope=TenantScope.TENANT)
+
+
+@pytest.fixture
+def admin_ctx() -> TenantContext:
+    return TenantContext(tenant="admin", site="demo", domain="local.test", scope=TenantScope.ADMIN)
+
+
+@pytest.mark.asyncio
+async def test_tile_service_crud_cycle_covers_admin_and_tenant_scopes(
+    admin_ctx: TenantContext, tenant_alpha: TenantContext
+) -> None:
+    tiles = InMemoryTable(DashboardTile)
+    permissions = InMemoryTable(DashboardTilePermission)
+    orm = FakeORM(tenants={"dashboard_tiles": tiles, "dashboard_tile_permissions": permissions}, admin={})
+    service = QuickstartTileService(orm)  # type: ignore[arg-type]
+
+    payload = TileCreate(
+        title="Revenue",
+        layout={"kind": "chart"},
+        description=None,
+        data_sources=("warehouse",),
+        ai_insights_enabled=True,
+    )
+    record = await service.create_tile(
+        tenant=admin_ctx,
+        workspace_id=tenant_alpha.tenant,
+        principal=None,
+        payload=payload,
+    )
+    assert record.workspace_id == tenant_alpha.tenant
+    assert record.ai_insights_enabled is True
+
+    unchanged = await service.update_tile(
+        tenant=tenant_alpha,
+        workspace_id=tenant_alpha.tenant,
+        tile_id=record.id,
+        principal=None,
+        payload=TileUpdate(),
+    )
+    assert unchanged.id == record.id
+
+    enriched = await service.update_tile(
+        tenant=tenant_alpha,
+        workspace_id=tenant_alpha.tenant,
+        tile_id=record.id,
+        principal=None,
+        payload=TileUpdate(
+            description="Revenue insights",
+            data_sources=("warehouse", "ml"),
+            ai_insights_enabled=True,
+        ),
+    )
+    assert enriched.data_sources == ("warehouse", "ml")
+
+    await service.set_permissions(
+        tenant=tenant_alpha,
+        workspace_id=tenant_alpha.tenant,
+        tile_id=record.id,
+        principal=None,
+        permissions=TilePermissions(roles=("analyst",), users=("user-1",)),
+    )
+    updated_perms = await service.set_permissions(
+        tenant=tenant_alpha,
+        workspace_id=tenant_alpha.tenant,
+        tile_id=record.id,
+        principal=None,
+        permissions=TilePermissions(roles=("analyst", "ops"), users=("user-2",)),
+    )
+    assert updated_perms.roles == ("analyst", "ops")
+
+    toggled = await service.toggle_ai_insights(
+        tenant=tenant_alpha,
+        workspace_id=tenant_alpha.tenant,
+        tile_id=record.id,
+        principal=None,
+        enabled=False,
+    )
+    assert toggled.ai_insights_enabled is False
+
+    refreshed = await service.update_tile(
+        tenant=tenant_alpha,
+        workspace_id=tenant_alpha.tenant,
+        tile_id=record.id,
+        principal=None,
+        payload=TileUpdate(title="Daily Revenue", layout={"kind": "table"}),
+    )
+    assert refreshed.title == "Daily Revenue"
+
+    await service.delete_tile(
+        tenant=tenant_alpha,
+        workspace_id=tenant_alpha.tenant,
+        tile_id=record.id,
+        principal=None,
+    )
+    assert await tiles.get(tenant=tenant_alpha, filters={"id": record.id}) is None
+    assert await permissions.list(tenant=tenant_alpha) == []
+
+    with pytest.raises(HTTPError) as missing_delete:
+        await service.delete_tile(
+            tenant=tenant_alpha,
+            workspace_id=tenant_alpha.tenant,
+            tile_id=record.id,
+            principal=None,
+        )
+    assert isinstance(missing_delete.value, HTTPError)
+    assert missing_delete.value.detail["detail"] == "tile_missing"
+
+    with pytest.raises(HTTPError) as missing_tile:
+        await service.update_tile(
+            tenant=tenant_alpha,
+            workspace_id=tenant_alpha.tenant,
+            tile_id=record.id,
+            principal=None,
+            payload=TileUpdate(title="fail"),
+        )
+    assert isinstance(missing_tile.value, HTTPError)
+    assert missing_tile.value.detail["detail"] == "tile_missing"
+
+    with pytest.raises(HTTPError) as missing_load:
+        await service.update_tile(
+            tenant=tenant_alpha,
+            workspace_id=tenant_alpha.tenant,
+            tile_id=record.id,
+            principal=None,
+            payload=TileUpdate(),
+        )
+    assert isinstance(missing_load.value, HTTPError)
+    assert missing_load.value.detail["detail"] == "tile_missing"
+
+    with pytest.raises(HTTPError) as missing_toggle:
+        await service.toggle_ai_insights(
+            tenant=tenant_alpha,
+            workspace_id=tenant_alpha.tenant,
+            tile_id=record.id,
+            principal=None,
+            enabled=True,
+        )
+    assert isinstance(missing_toggle.value, HTTPError)
+    assert missing_toggle.value.detail["detail"] == "tile_missing"
+
+
+@pytest.mark.asyncio
+async def test_rbac_service_creates_roles_and_assigns_users(
+    admin_ctx: TenantContext, tenant_alpha: TenantContext
+) -> None:
+    permission_sets = InMemoryTable(WorkspacePermissionSet)
+    role_assignments = InMemoryTable(WorkspaceRoleAssignment)
+    roles = InMemoryTable(Role)
+    permissions = InMemoryTable(Permission)
+    orm = FakeORM(
+        tenants={
+            "workspace_permission_sets": permission_sets,
+            "workspace_role_assignments": role_assignments,
+        },
+        admin={"roles": roles, "permissions": permissions},
+    )
+    service = QuickstartRbacService(orm)  # type: ignore[arg-type]
+
+    created = await service.create_permission_set(
+        tenant=admin_ctx,
+        workspace_id=tenant_alpha.tenant,
+        principal=None,
+        payload=PermissionSetCreate(name="ops", permissions=("tiles:view", "tiles:view", "tiles:edit")),
+    )
+    assert created.permissions == ("tiles:view", "tiles:edit")
+    assert await roles.get(tenant=None, filters={"id": created.role_id}) is not None
+    assert len(await permissions.list(tenant=None, filters={"role_id": created.role_id})) == 2
+
+    with pytest.raises(HTTPError) as duplicate:
+        await service.create_permission_set(
+            tenant=tenant_alpha,
+            workspace_id=tenant_alpha.tenant,
+            principal=None,
+            payload=PermissionSetCreate(name="ops", permissions=("tiles:view",)),
+        )
+    assert isinstance(duplicate.value, HTTPError)
+    assert duplicate.value.status == 409
+
+    assigned = await service.assign_role(
+        tenant=tenant_alpha,
+        workspace_id=tenant_alpha.tenant,
+        role_id=created.role_id,
+        principal=None,
+        payload=RoleAssignment(user_ids=("u1", "u2")),
+    )
+    assert assigned.assigned_user_ids == ("u1", "u2")
+
+    again = await service.assign_role(
+        tenant=tenant_alpha,
+        workspace_id=tenant_alpha.tenant,
+        role_id=created.role_id,
+        principal=None,
+        payload=RoleAssignment(user_ids=("u1", "u3")),
+    )
+    assert again.assigned_user_ids == ("u1", "u3")
+    assert len(await role_assignments.list(tenant=tenant_alpha)) == 3
+
+    with pytest.raises(HTTPError) as missing_set:
+        await service.assign_role(
+            tenant=tenant_alpha,
+            workspace_id=tenant_alpha.tenant,
+            role_id="missing",
+            principal=None,
+            payload=RoleAssignment(user_ids=("u5",)),
+        )
+    assert isinstance(missing_set.value, HTTPError)
+    assert missing_set.value.detail["detail"] == "permission_set_missing"
+
+
+@pytest.mark.asyncio
+async def test_delegation_service_grant_merge_revoke_and_resolution(
+    tenant_alpha: TenantContext, tenant_beta: TenantContext, admin_ctx: TenantContext
+) -> None:
+    delegations = InMemoryTable(WorkspacePermissionDelegation)
+    permission_sets = InMemoryTable(WorkspacePermissionSet)
+    assignments = InMemoryTable(WorkspaceRoleAssignment)
+    orm = FakeORM(
+        tenants={
+            "permission_delegations": delegations,
+            "workspace_permission_sets": permission_sets,
+            "workspace_role_assignments": assignments,
+        },
+        admin={},
+    )
+    clock = TickingClock(dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc))
+    service = QuickstartDelegationService(orm, clock=clock.now)  # type: ignore[arg-type]
+
+    with pytest.raises(HTTPError) as window_error:
+        await service.grant(
+            tenant=tenant_alpha,
+            principal=None,
+            payload=DelegationGrant(
+                from_user_id="grantor",
+                to_user_id="delegate",
+                scopes=("tiles:view",),
+                workspace_id=tenant_alpha.tenant,
+                starts_at=clock.now(),
+                ends_at=clock.now(),
+            ),
+        )
+    assert isinstance(window_error.value, HTTPError)
+    assert window_error.value.detail["detail"] == "invalid_window"
+
+    await permission_sets.create(
+        WorkspacePermissionSet(
+            workspace_id=tenant_alpha.tenant,
+            name="ops",
+            permissions=("tiles:view", "tiles:edit"),
+            role_id="role-ops",
+        ),
+        tenant=tenant_alpha,
+    )
+    await assignments.create(
+        WorkspaceRoleAssignment(
+            workspace_id=tenant_alpha.tenant,
+            role_id="role-ops",
+            user_id="grantor",
+            assigned_at=clock.now(),
+        ),
+        tenant=tenant_alpha,
+    )
+
+    await delegations.create(
+        WorkspacePermissionDelegation(
+            workspace_id=tenant_alpha.tenant,
+            from_user_id="grantor",
+            to_user_id="delegate",
+            scopes=("tiles:view",),
+            starts_at=clock.now() - dt.timedelta(days=3),
+            ends_at=clock.now() - dt.timedelta(days=2),
+        ),
+        tenant=tenant_alpha,
+    )
+    await assignments.create(
+        WorkspaceRoleAssignment(
+            workspace_id=tenant_alpha.tenant,
+            role_id="ghost",
+            user_id="delegate",
+            assigned_at=clock.now(),
+        ),
+        tenant=tenant_alpha,
+    )
+
+    with pytest.raises(HTTPError) as scope_error:
+        await service.grant(
+            tenant=tenant_alpha,
+            principal=None,
+            payload=DelegationGrant(
+                from_user_id="grantor",
+                to_user_id="delegate",
+                scopes=("tiles:manage",),
+                workspace_id=tenant_alpha.tenant,
+                starts_at=clock.now(),
+                ends_at=clock.now() + dt.timedelta(hours=1),
+            ),
+        )
+    assert isinstance(scope_error.value, HTTPError)
+    assert scope_error.value.detail["detail"] == "scope_not_granted"
+
+    start = clock.now() - dt.timedelta(hours=1)
+    end = clock.now() + dt.timedelta(hours=1)
+    first = await service.grant(
+        tenant=tenant_alpha,
+        principal=None,
+        payload=DelegationGrant(
+            from_user_id="grantor",
+            to_user_id="delegate",
+            scopes=("tiles:view",),
+            workspace_id=tenant_alpha.tenant,
+            starts_at=start,
+            ends_at=end,
+        ),
+    )
+    assert first.scopes == ("tiles:view",)
+
+    extended = await service.grant(
+        tenant=tenant_alpha,
+        principal=None,
+        payload=DelegationGrant(
+            from_user_id="grantor",
+            to_user_id="delegate",
+            scopes=("tiles:edit",),
+            workspace_id=tenant_alpha.tenant,
+            starts_at=clock.now(),
+            ends_at=clock.now() + dt.timedelta(hours=2),
+        ),
+    )
+    assert extended.scopes == ("tiles:edit", "tiles:view")
+
+    active = await service.list_active(
+        tenant=tenant_alpha,
+        principal=None,
+        user_id="delegate",
+    )
+    assert active[0].scopes == extended.scopes
+
+    active_ws = await service.list_active(
+        tenant=tenant_alpha,
+        principal=None,
+        user_id="delegate",
+        workspace_id=tenant_alpha.tenant,
+    )
+    assert active_ws[0].workspace_id == tenant_alpha.tenant
+
+    with pytest.raises(HTTPError) as forbidden_list:
+        await service.list_active(
+            tenant=admin_ctx,
+            principal=None,
+        )
+    assert isinstance(forbidden_list.value, HTTPError)
+    assert forbidden_list.value.detail["detail"] == "tenant_required"
+
+    permissions_for_delegate = await service.resolve_effective_permissions(
+        tenant=tenant_alpha,
+        principal=None,
+        user_id="delegate",
+        workspace_id=tenant_alpha.tenant,
+    )
+    assert permissions_for_delegate == ("tiles:edit", "tiles:view")
+
+    await delegations.create(
+        WorkspacePermissionDelegation(
+            workspace_id=tenant_beta.tenant,
+            from_user_id="grantor",
+            to_user_id="delegate",
+            scopes=("tiles:view",),
+            starts_at=start,
+            ends_at=end,
+        ),
+        tenant=tenant_beta,
+    )
+    await delegations.create(
+        WorkspacePermissionDelegation(
+            workspace_id="other",
+            from_user_id="grantor",
+            to_user_id="delegate",
+            scopes=("tiles:view",),
+            starts_at=start,
+            ends_at=end,
+        ),
+        tenant=tenant_alpha,
+    )
+    filtered_scopes = await service.resolve_effective_permissions(
+        tenant=tenant_alpha,
+        principal=None,
+        user_id="delegate",
+        workspace_id=tenant_alpha.tenant,
+    )
+    assert filtered_scopes == ("tiles:edit", "tiles:view")
+    cross_workspace = await service.resolve_effective_permissions(
+        tenant=tenant_alpha,
+        principal=None,
+        user_id="delegate",
+    )
+    assert cross_workspace == ("tiles:edit", "tiles:view")
+
+    with pytest.raises(HTTPError) as forbidden_resolve:
+        await service.resolve_effective_permissions(
+            tenant=admin_ctx,
+            principal=None,
+            user_id="delegate",
+        )
+    assert isinstance(forbidden_resolve.value, HTTPError)
+    assert forbidden_resolve.value.detail["detail"] == "tenant_required"
+
+    with pytest.raises(HTTPError) as forbidden_revoke:
+        await service.revoke(
+            tenant=admin_ctx,
+            principal=None,
+            delegation_id=first.id,
+        )
+    assert isinstance(forbidden_revoke.value, HTTPError)
+    assert forbidden_revoke.value.detail["detail"] == "tenant_required"
+
+    clock.value = clock.now() + dt.timedelta(hours=3)
+    await service.revoke(
+        tenant=tenant_alpha,
+        principal=None,
+        delegation_id=first.id,
+    )
+
+    clock.value = clock.now() + dt.timedelta(seconds=1)
+    now_empty = await service.list_active(
+        tenant=tenant_alpha,
+        principal=None,
+        user_id="delegate",
+        workspace_id=tenant_alpha.tenant,
+    )
+    assert now_empty == ()
+
+    with pytest.raises(HTTPError) as missing_delegate:
+        await service.revoke(
+            tenant=tenant_alpha,
+            principal=None,
+            delegation_id="missing",
+        )
+    assert isinstance(missing_delegate.value, HTTPError)
+    assert missing_delegate.value.detail["detail"] == "delegation_missing"
+
+
+@pytest.mark.asyncio
+async def test_audit_service_filters_and_exports(admin_ctx: TenantContext, tenant_alpha: TenantContext) -> None:
+    audit_log = InMemoryTable(AuditRow)
+    orm = FakeORM(tenants={"audit_log": audit_log}, admin={})
+    service = QuickstartAuditService(orm)  # type: ignore[arg-type]
+
+    base = dt.datetime(2024, 5, 1, tzinfo=dt.timezone.utc)
+    await audit_log.create(
+        AuditRow(
+            id="evt-1",
+            created_at=base - dt.timedelta(days=1),
+            actor_id="user-1",
+            actor_type="user",
+            action="tile.created",
+            entity_type="tile",
+            entity_id="tile-1",
+            metadata={"shape": "chart"},
+        ),
+        tenant=tenant_alpha,
+    )
+    await audit_log.create(
+        AuditRow(
+            id="evt-2",
+            created_at=base,
+            actor_id="sa-1",
+            actor_type="sysadmin",
+            action="tile.deleted",
+            entity_type="tile",
+            entity_id="tile-2",
+            metadata={},
+        ),
+        tenant=tenant_alpha,
+    )
+    await audit_log.create(
+        AuditRow(
+            id="evt-3",
+            created_at=base + dt.timedelta(days=1),
+            actor_id="user-2",
+            actor_type="user",
+            action="workspace.updated",
+            entity_type="workspace",
+            entity_id=None,
+            metadata={},
+        ),
+        tenant=tenant_alpha,
+    )
+
+    page = await service.read(
+        tenant=admin_ctx,
+        workspace_id=tenant_alpha.tenant,
+        principal=None,
+        actor="sa-1",
+        action="tile.deleted",
+        entity="tile",
+        from_time=base - dt.timedelta(hours=1),
+        to_time=base + dt.timedelta(hours=1),
+    )
+    assert len(page.entries) == 1
+    assert page.entries[0].actor.endswith("sysadmin")
+
+    csv_export = await service.export(
+        tenant=admin_ctx,
+        workspace_id=tenant_alpha.tenant,
+        principal=None,
+        query=AuditLogExportQuery(format="csv"),
+        action="tile.deleted",
+    )
+    assert csv_export.content_type == "text/csv"
+    assert csv_export.filename == f"audit-{tenant_alpha.tenant}.csv"
+
+    json_export = await service.export(
+        tenant=admin_ctx,
+        workspace_id=tenant_alpha.tenant,
+        principal=None,
+        query=AuditLogExportQuery(format="json"),
+        actor=None,
+    )
+    assert json_export.content_type == "application/json"
+
+    workspace_page = await service.read(
+        tenant=admin_ctx,
+        workspace_id=tenant_alpha.tenant,
+        principal=None,
+        actor=None,
+        action=None,
+        entity="workspace",
+    )
+    assert len(workspace_page.entries) == 1
+
+    recent_page = await service.read(
+        tenant=admin_ctx,
+        workspace_id=tenant_alpha.tenant,
+        principal=None,
+        actor=None,
+        action=None,
+        from_time=base,
+    )
+    assert all(entry.timestamp >= base for entry in recent_page.entries)
+
+    bounded_page = await service.read(
+        tenant=admin_ctx,
+        workspace_id=tenant_alpha.tenant,
+        principal=None,
+        actor=None,
+        action=None,
+        to_time=base,
+    )
+    assert all(entry.timestamp <= base for entry in bounded_page.entries)
+
+
+@pytest.mark.asyncio
+async def test_build_cedar_engine_includes_assignments_and_delegations(
+    tenant_alpha: TenantContext, admin_ctx: TenantContext
+) -> None:
+    permission_sets = InMemoryTable(WorkspacePermissionSet)
+    assignments = InMemoryTable(WorkspaceRoleAssignment)
+    delegations = InMemoryTable(WorkspacePermissionDelegation)
+    orm = FakeORM(
+        tenants={
+            "workspace_permission_sets": permission_sets,
+            "workspace_role_assignments": assignments,
+            "permission_delegations": delegations,
+        },
+        admin={},
+    )
+    await permission_sets.create(
+        WorkspacePermissionSet(
+            workspace_id=tenant_alpha.tenant,
+            name="ops",
+            permissions=("tiles:view", "tiles:edit"),
+            role_id="role-ops",
+        ),
+        tenant=tenant_alpha,
+    )
+    now = dt.datetime(2024, 5, 1, tzinfo=dt.timezone.utc)
+    await assignments.create(
+        WorkspaceRoleAssignment(
+            workspace_id=tenant_alpha.tenant,
+            role_id="role-ops",
+            user_id="analyst",
+            assigned_at=now,
+        ),
+        tenant=tenant_alpha,
+    )
+    await assignments.create(
+        WorkspaceRoleAssignment(
+            workspace_id=tenant_alpha.tenant,
+            role_id="ghost-role",
+            user_id="bystander",
+            assigned_at=now,
+        ),
+        tenant=tenant_alpha,
+    )
+    await delegations.create(
+        WorkspacePermissionDelegation(
+            workspace_id=tenant_alpha.tenant,
+            from_user_id="analyst",
+            to_user_id="delegate",
+            scopes=("tiles:view",),
+            starts_at=now - dt.timedelta(days=1),
+            ends_at=now + dt.timedelta(days=1),
+        ),
+        tenant=tenant_alpha,
+    )
+    await delegations.create(
+        WorkspacePermissionDelegation(
+            workspace_id=tenant_alpha.tenant,
+            from_user_id="analyst",
+            to_user_id="delegate",
+            scopes=("tiles:edit",),
+            starts_at=now - dt.timedelta(days=3),
+            ends_at=now - dt.timedelta(days=2),
+        ),
+        tenant=tenant_alpha,
+    )
+
+    engine = await build_cedar_engine(orm, tenant=tenant_alpha, at=now)  # type: ignore[arg-type]
+    policies = list(engine.policies())
+    assert len(policies) == 3
+    assert any(
+        policy.principal == CedarReference("User", "delegate") and "tiles:view" in policy.actions
+        for policy in policies
+    )
+    analyst = CedarEntity(type="User", id="analyst")
+    resource = CedarEntity(type="workspace", id=tenant_alpha.tenant)
+    assert engine.check(principal=analyst, action="tiles:edit", resource=resource)
+
+    with pytest.raises(HTTPError) as forbidden:
+        await build_cedar_engine(orm, tenant=admin_ctx, at=now)  # type: ignore[arg-type]
+    assert isinstance(forbidden.value, HTTPError)
+    assert forbidden.value.detail["detail"] == "tenant_required"


### PR DESCRIPTION
## Summary
- implement concrete quickstart domain services for tiles, RBAC, delegations, audit logging, and Cedar engine construction and wire them into the quickstart app
- extend delegation contracts and persistence with workspace-aware records used by the new services
- add comprehensive tests covering the quickstart services and dependency wiring to retain full coverage

## Testing
- `uv run ruff check src/artemis/quickstart.py src/artemis/domain/services.py src/artemis/domain/quickstart_services.py src/artemis/models.py tests/test_quickstart.py tests/test_quickstart_services.py`
- `uv run ty check`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d558ae9fa8832ea79931577cef907e