### PR TITLE
chore: format project and satisfy lint checks

### DIFF
--- a/src/artemis/audit.py
+++ b/src/artemis/audit.py
@@ -41,9 +41,7 @@ class AuditContext:
     actor: AuditActor | None
 
 
-_AUDIT_CONTEXT: ContextVar[AuditContext | None] = ContextVar[AuditContext | None](
-    "artemis_audit_context", default=None
-)
+_AUDIT_CONTEXT: ContextVar[AuditContext | None] = ContextVar[AuditContext | None]("artemis_audit_context", default=None)
 
 
 @asynccontextmanager

--- a/src/artemis/authentication.py
+++ b/src/artemis/authentication.py
@@ -78,9 +78,7 @@ class AuthenticationError(RuntimeError):
     """Raised when authentication fails."""
 
 
-def compose_admin_secret(
-    app_secret: AppSecret, user: AdminUser, *, resolver: SecretResolver
-) -> str:
+def compose_admin_secret(app_secret: AppSecret, user: AdminUser, *, resolver: SecretResolver) -> str:
     secret_value = app_secret.resolve_secret(resolver)
     return "::".join(["admin", secret_value, user.password_secret])
 
@@ -270,9 +268,7 @@ class AuthenticationService:
         self._secret_resolver = secret_resolver
         self._rate_limiter = rate_limiter or AuthenticationRateLimiter()
 
-    async def hash_admin_password(
-        self, *, app_secret: AppSecret, user_secret: str, password: str
-    ) -> tuple[str, str]:
+    async def hash_admin_password(self, *, app_secret: AppSecret, user_secret: str, password: str) -> tuple[str, str]:
         salt = secrets.token_hex(16)
         secret_value = app_secret.resolve_secret(self._secret_resolver)
         secret_key = "::".join(["admin", secret_value, user_secret])
@@ -308,9 +304,7 @@ class AuthenticationService:
         tenant_secret: TenantSecret,
         password: str,
     ) -> bool:
-        secret = compose_tenant_secret(
-            app_secret, tenant_secret, user, resolver=self._secret_resolver
-        )
+        secret = compose_tenant_secret(app_secret, tenant_secret, user, resolver=self._secret_resolver)
         return await self.password_hasher.verify(
             password, secret_key=secret, salt=user.password_salt, expected=user.hashed_password
         )
@@ -369,9 +363,7 @@ class AuthenticationService:
             raise AuthenticationError("passkey_user_mismatch")
         return self._issue_session_token(user_id=passkey.user_id, level=SessionLevel.PASSKEY)
 
-    def _rate_limit_keys(
-        self, *, user: TenantUser, tenant_secret: TenantSecret, client: str | None
-    ) -> list[str]:
+    def _rate_limit_keys(self, *, user: TenantUser, tenant_secret: TenantSecret, client: str | None) -> list[str]:
         keys = [f"user:{user.id}", f"tenant:{tenant_secret.id}"]
         if client:
             keys.append(f"client:{client}")
@@ -649,9 +641,7 @@ class AuthenticationFlowEngine(Generic[LoginUserT, SessionT]):
                 secret=record[1].encode("utf-8"),
                 user_handle=f"{getattr(flow.user, 'id')}:{flow.tenant}",
             )
-            if not self._passkey_manager.verify(
-                passkey=passkey, challenge=challenge, signature=attempt.signature
-            ):
+            if not self._passkey_manager.verify(passkey=passkey, challenge=challenge, signature=attempt.signature):
                 self._register_failure(flow)
                 raise HTTPError(Status.UNAUTHORIZED, {"detail": "invalid_passkey"})
             self._reset_attempts(flow)
@@ -735,8 +725,7 @@ class AuthenticationFlowEngine(Generic[LoginUserT, SessionT]):
         if flow.step is LoginStep.PASSKEY:
             payload["challenge"] = flow.challenge
             payload["credential_ids"] = tuple(
-                getattr(passkey, "credential_id")
-                for passkey in getattr(flow.user, "passkeys", ())
+                getattr(passkey, "credential_id") for passkey in getattr(flow.user, "passkeys", ())
             )
         provider = getattr(flow.user, "sso", None) if flow.step is LoginStep.SSO else None
         return AuthenticationFlowResponse(
@@ -1199,9 +1188,7 @@ class SamlAuthenticator:
                 if now - skew >= not_on_or_after:
                     raise AuthenticationError("assertion_expired")
 
-        for data in tree.findall(
-            ".//saml2:SubjectConfirmation/saml2:SubjectConfirmationData", namespaces=ns
-        ):
+        for data in tree.findall(".//saml2:SubjectConfirmation/saml2:SubjectConfirmationData", namespaces=ns):
             data_not_before = data.get("NotBefore")
             if data_not_before:
                 not_before = parse_instant(data_not_before)
@@ -1262,9 +1249,7 @@ def _b64url_decode(data: str) -> bytes:
 
 def _derive_session_token_hash(token: str, salt_hex: str) -> str:
     salt = bytes.fromhex(salt_hex)
-    derived = hashlib.pbkdf2_hmac(
-        "sha256", token.encode(), salt, _SESSION_TOKEN_PBKDF2_ITERATIONS
-    )
+    derived = hashlib.pbkdf2_hmac("sha256", token.encode(), salt, _SESSION_TOKEN_PBKDF2_ITERATIONS)
     return derived.hex()
 
 

--- a/src/artemis/chatops.py
+++ b/src/artemis/chatops.py
@@ -7,8 +7,7 @@ import hashlib
 import inspect
 import shlex
 import ssl
-from typing import Any, Awaitable, Callable, Iterable, Mapping, Protocol, Sequence
-from typing import Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable, Literal, Mapping, Protocol, Sequence
 from urllib.parse import urlparse
 
 import msgspec
@@ -301,11 +300,7 @@ class ChatOpsService:
                 if command.visibility == "admin":
                     if tenant.scope is not TenantScope.ADMIN:
                         raise ChatOpsCommandResolutionError("admin_command")
-                    if (
-                        admin_workspace is None
-                        or workspace_id is None
-                        or workspace_id != admin_workspace
-                    ):
+                    if admin_workspace is None or workspace_id is None or workspace_id != admin_workspace:
                         raise ChatOpsCommandResolutionError("workspace_forbidden")
                 else:
                     if tenant.scope is not TenantScope.ADMIN and not self.is_configured(tenant):
@@ -494,16 +489,16 @@ def _validate_certificate_pin(response: Any, pins: Iterable[str]) -> None:
 
 
 __all__ = [
-    "ChatOpsInvocationError",
-    "ChatOpsCommandResolutionError",
     "ChatMessage",
+    "ChatOpsCommandResolutionError",
     "ChatOpsConfig",
     "ChatOpsError",
+    "ChatOpsInvocationError",
     "ChatOpsRoute",
     "ChatOpsService",
     "ChatOpsSlashCommand",
     "ChatOpsSlashCommandInvocation",
-    "parse_slash_command_args",
     "SlackWebhookConfig",
     "SlashCommandVisibility",
+    "parse_slash_command_args",
 ]

--- a/src/artemis/codegen.py
+++ b/src/artemis/codegen.py
@@ -257,9 +257,7 @@ class _TypeScriptEmitter:
             "}",
         ]
 
-    def _operation_metadata(
-        self, path: str, method: str, operation: Mapping[str, Any]
-    ) -> _OperationMetadata:
+    def _operation_metadata(self, path: str, method: str, operation: Mapping[str, Any]) -> _OperationMetadata:
         name = _sanitize_operation_id(operation.get("operationId", f"{method.lower()}_{path}"))
         type_base = _type_name_from_path(path, method)
         input_type = f"{type_base}Input"

--- a/src/artemis/database.py
+++ b/src/artemis/database.py
@@ -35,8 +35,7 @@ class SecretRef(msgspec.Struct, frozen=True, omit_defaults=True):
 class SecretResolver(Protocol):
     """Resolve secret references into concrete values."""
 
-    def resolve(self, secret: SecretRef) -> str:
-        ...
+    def resolve(self, secret: SecretRef) -> str: ...
 
 
 class SecretValue(msgspec.Struct, frozen=True, omit_defaults=True):

--- a/src/artemis/domain/quickstart_services.py
+++ b/src/artemis/domain/quickstart_services.py
@@ -339,11 +339,7 @@ class QuickstartDelegationService(DelegationService):
 
     @staticmethod
     def _principal_matches_user(principal: CedarEntity | None, user_id: str) -> bool:
-        return (
-            isinstance(principal, CedarEntity)
-            and principal.type == "User"
-            and principal.id == user_id
-        )
+        return isinstance(principal, CedarEntity) and principal.type == "User" and principal.id == user_id
 
     @staticmethod
     def _principal_is_admin(principal: CedarEntity | None, tenant: TenantContext) -> bool:
@@ -365,8 +361,7 @@ class QuickstartDelegationService(DelegationService):
         if payload.starts_at >= payload.ends_at:
             raise HTTPError(Status.BAD_REQUEST, {"detail": "invalid_window"})
         if not (
-            self._principal_matches_user(principal, payload.from_user_id)
-            or self._principal_is_admin(principal, target)
+            self._principal_matches_user(principal, payload.from_user_id) or self._principal_is_admin(principal, target)
         ):
             raise HTTPError(Status.FORBIDDEN, {"detail": "delegation_forbidden"})
         grantor_scopes = set(
@@ -475,11 +470,7 @@ class QuickstartDelegationService(DelegationService):
             tenant=target,
             filters=filters or None,
         )
-        return tuple(
-            self._to_record(item)
-            for item in entries
-            if item.starts_at <= now <= item.ends_at
-        )
+        return tuple(self._to_record(item) for item in entries if item.starts_at <= now <= item.ends_at)
 
     async def resolve_effective_permissions(
         self,
@@ -498,9 +489,7 @@ class QuickstartDelegationService(DelegationService):
         )
         assignments = await self._orm.tenants.workspace_role_assignments.list(
             tenant=target,
-            filters={"workspace_id": workspace_id, "user_id": user_id}
-            if workspace_id
-            else {"user_id": user_id},
+            filters={"workspace_id": workspace_id, "user_id": user_id} if workspace_id else {"user_id": user_id},
         )
         permission_map = {record.role_id: record for record in sets}
         scopes: set[str] = set()

--- a/src/artemis/events.py
+++ b/src/artemis/events.py
@@ -125,6 +125,7 @@ class EventStream:
             async def runner() -> None:
                 outcome = await executor.run(func, *args, mode=mode, **kwargs)
                 await self._emit_from_result(outcome)
+
             task = loop.create_task(runner())
         self._background.add(task)
         task.add_done_callback(self._background.discard)

--- a/src/artemis/golden.py
+++ b/src/artemis/golden.py
@@ -35,9 +35,7 @@ class GoldenFile:
             return
         diff = self._diff(existing or "", rendered)
         hint = self._approval_env[0] if self._approval_env else "ARTEMIS_APPROVE_GOLDEN"
-        message = (
-            f"Golden file {self.path} is out of date. Set {hint}=1 to approve updates.\n{diff}".rstrip()
-        )
+        message = f"Golden file {self.path} is out of date. Set {hint}=1 to approve updates.\n{diff}".rstrip()
         raise AssertionError(message)
 
     def _should_approve(self) -> bool:

--- a/src/artemis/http.py
+++ b/src/artemis/http.py
@@ -100,4 +100,3 @@ __all__ = [
     "is_success",
     "reason_phrase",
 ]
-

--- a/src/artemis/orm.py
+++ b/src/artemis/orm.py
@@ -251,9 +251,7 @@ class ORM:
 
     def _ensure_exposed(self, info: ModelInfo[Any]) -> None:
         if not info.exposed:
-            raise PermissionError(
-                f"Model {info.model.__name__} is restricted and cannot be accessed via the ORM"
-            )
+            raise PermissionError(f"Model {info.model.__name__} is restricted and cannot be accessed via the ORM")
 
     async def _insert(self, info: ModelInfo[M], instance: M, tenant: TenantContext | None) -> M:
         payload = msgspec.to_builtins(instance)
@@ -505,9 +503,7 @@ class _Namespace:
         except KeyError:
             info = self._orm.registry.get_by_accessor(self._scope, item)
             if not info.exposed:
-                raise AttributeError(
-                    f"Model accessor '{item}' in scope '{self._scope}' is restricted"
-                )
+                raise AttributeError(f"Model accessor '{item}' in scope '{self._scope}' is restricted")
             manager = ModelManager(self._orm, info)
             self._cache[item] = manager
             return manager

--- a/src/artemis/rbac.py
+++ b/src/artemis/rbac.py
@@ -306,9 +306,7 @@ class _CedarPyRuntime:
         self._module = module
         self._policies_text = policies_text
         self._schema_json = schema_json
-        self._principal_attributes = {
-            key: dict(value) for key, value in principal_attributes.items()
-        }
+        self._principal_attributes = {key: dict(value) for key, value in principal_attributes.items()}
 
     @classmethod
     def build(cls, policies: Sequence[CedarPolicy]) -> _CedarPyRuntime | None:
@@ -442,8 +440,7 @@ class _CedarPolicyCompiler:
                 "shape": {
                     "type": "Record",
                     "attributes": {
-                        name: {"type": attr_type, "required": False}
-                        for name, attr_type in sorted(attributes.items())
+                        name: {"type": attr_type, "required": False} for name, attr_type in sorted(attributes.items())
                     },
                 }
             }
@@ -476,11 +473,11 @@ class _CedarPolicyCompiler:
 
 
 def _format_entity_reference(entity: CedarEntity) -> str:
-    return f"{entity.type}::\"{_escape_string(entity.id)}\""
+    return f'{entity.type}::"{_escape_string(entity.id)}"'
 
 
 def _action_literal(action: str) -> str:
-    return f"Action::\"{_escape_string(action)}\""
+    return f'Action::"{_escape_string(action)}"'
 
 
 def _serialize_entity(entity: CedarEntity, attribute_types: Mapping[str, str]) -> Mapping[str, Any]:
@@ -508,7 +505,7 @@ def _render_reference(label: str, reference: CedarReference) -> tuple[str | None
     if identifier in (None, "*"):
         clause = f"{label} is {entity_type}"
     else:
-        clause = f"{label} == {entity_type}::\"{_escape_string(identifier)}\""
+        clause = f'{label} == {entity_type}::"{_escape_string(identifier)}"'
     return clause, entity_type
 
 
@@ -584,7 +581,7 @@ def _cedar_attribute_value(value: Any, attr_type: str) -> Any | None:
 
 
 def _escape_string(value: str) -> str:
-    return value.replace("\\", "\\\\").replace('"', "\\\"")
+    return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
 __all__ = [

--- a/src/artemis/serialization.py
+++ b/src/artemis/serialization.py
@@ -29,11 +29,7 @@ def _sanitize_for_json(value: Any) -> Any:
         info = getattr(value, "__model_info__", None)
         redacted = getattr(info, "redacted_fields", frozenset()) if info is not None else frozenset()
         payload = structs.asdict(value)
-        return {
-            key: _sanitize_for_json(val)
-            for key, val in payload.items()
-            if key not in redacted
-        }
+        return {key: _sanitize_for_json(val) for key, val in payload.items() if key not in redacted}
     if isinstance(value, dict):
         return {key: _sanitize_for_json(val) for key, val in value.items()}
     if isinstance(value, (list, tuple, set, frozenset)):

--- a/src/artemis/websockets.py
+++ b/src/artemis/websockets.py
@@ -170,6 +170,7 @@ class WebSocket:
             async def runner() -> None:
                 outcome = await self._executor.run(func, *args, mode=mode, **kwargs)
                 await self._send_from_result(outcome)
+
             task = loop.create_task(runner())
         self._background.add(task)
         task.add_done_callback(self._background.discard)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -140,9 +140,7 @@ async def test_admin_route_requires_admin_scope(app: ArtemisApp) -> None:
         forbidden = await client.get("/admin/tenants", tenant="acme")
         assert forbidden.status == 403
         payload = json_decode(forbidden.body)
-        assert payload == {
-            "error": {"status": 403, "reason": "Forbidden", "detail": "admin scope required"}
-        }
+        assert payload == {"error": {"status": 403, "reason": "Forbidden", "detail": "admin scope required"}}
 
 
 @pytest.mark.asyncio

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -815,6 +815,7 @@ async def test_authentication_rate_limiter_locks_after_failures() -> None:
     assert session.expires_at == session.record.expires_at
     assert session.revoked_at is None
 
+
 def test_passkey_authentication_failures() -> None:
     resolver = StaticSecretResolver({})
     service = AuthenticationService(
@@ -1014,18 +1015,14 @@ def test_oidc_authenticator_rejects_invalid_token_structures() -> None:
 
     header = _b64url(json.dumps({"alg": "HS256"}).encode())
     payload = _b64url(b"not-json")
-    signature_invalid_json = _b64url(
-        hmac.new(secret, f"{header}.{payload}".encode(), hashlib.sha256).digest()
-    )
+    signature_invalid_json = _b64url(hmac.new(secret, f"{header}.{payload}".encode(), hashlib.sha256).digest())
     token = f"{header}.{payload}.{signature_invalid_json}"
     with pytest.raises(AuthenticationError) as exc:
         authenticator.validate(token, now=now)
     assert str(exc.value) == "invalid_token"
 
     payload = _b64url(json.dumps(["not", "mapping"]).encode())
-    signature_invalid_mapping = _b64url(
-        hmac.new(secret, f"{header}.{payload}".encode(), hashlib.sha256).digest()
-    )
+    signature_invalid_mapping = _b64url(hmac.new(secret, f"{header}.{payload}".encode(), hashlib.sha256).digest())
     token = f"{header}.{payload}.{signature_invalid_mapping}"
     with pytest.raises(AuthenticationError) as exc:
         authenticator.validate(token, now=now)
@@ -1212,9 +1209,7 @@ def test_oidc_authenticator_signature_edge_cases() -> None:
         "exp": _epoch(now + dt.timedelta(minutes=5)),
     }
 
-    jwks_oct = {
-        "keys": [{"kty": "oct", "kid": "primary", "k": _b64url(secret)}]
-    }
+    jwks_oct = {"keys": [{"kty": "oct", "kid": "primary", "k": _b64url(secret)}]}
     authenticator = OidcAuthenticator(
         provider,
         jwks_fetcher=lambda _: jwks_oct,
@@ -1322,9 +1317,7 @@ def test_oidc_authenticator_rsa_signature_paths() -> None:
         authenticator.validate(token, now=now)
     assert str(exc.value) == "unsupported_algorithm"
 
-    jwks_bad_fields = {
-        "keys": [{"kty": "RSA", "kid": "rsa", "n": None, "e": _b64url(exponent)}]
-    }
+    jwks_bad_fields = {"keys": [{"kty": "RSA", "kid": "rsa", "n": None, "e": _b64url(exponent)}]}
     authenticator = OidcAuthenticator(
         provider,
         jwks_fetcher=lambda _: jwks_bad_fields,
@@ -1335,9 +1328,7 @@ def test_oidc_authenticator_rsa_signature_paths() -> None:
         authenticator.validate(token, now=now)
     assert str(exc.value) == "invalid_jwks"
 
-    jwks_bad_base64 = {
-        "keys": [{"kty": "RSA", "kid": "rsa", "n": "-!", "e": _b64url(exponent)}]
-    }
+    jwks_bad_base64 = {"keys": [{"kty": "RSA", "kid": "rsa", "n": "-!", "e": _b64url(exponent)}]}
     authenticator = OidcAuthenticator(
         provider,
         jwks_fetcher=lambda _: jwks_bad_base64,
@@ -1348,9 +1339,7 @@ def test_oidc_authenticator_rsa_signature_paths() -> None:
         authenticator.validate(token, now=now)
     assert str(exc.value) == "invalid_jwks"
 
-    jwks_zero_modulus = {
-        "keys": [{"kty": "RSA", "kid": "rsa", "n": _b64url(b"\x00"), "e": _b64url(exponent)}]
-    }
+    jwks_zero_modulus = {"keys": [{"kty": "RSA", "kid": "rsa", "n": _b64url(b"\x00"), "e": _b64url(exponent)}]}
     authenticator = OidcAuthenticator(
         provider,
         jwks_fetcher=lambda _: jwks_zero_modulus,
@@ -1362,9 +1351,7 @@ def test_oidc_authenticator_rsa_signature_paths() -> None:
     assert str(exc.value) == "invalid_jwks"
 
     small_modulus = b"\x01" * 16
-    jwks_small = {
-        "keys": [{"kty": "RSA", "kid": "rsa", "n": _b64url(small_modulus), "e": _b64url(exponent)}]
-    }
+    jwks_small = {"keys": [{"kty": "RSA", "kid": "rsa", "n": _b64url(small_modulus), "e": _b64url(exponent)}]}
     authenticator = OidcAuthenticator(
         provider,
         jwks_fetcher=lambda _: jwks_small,
@@ -1381,9 +1368,7 @@ def test_oidc_authenticator_rsa_signature_paths() -> None:
         authenticator.validate(token, now=now)
     assert str(exc.value) == "invalid_jwks"
 
-    jwks_large = {
-        "keys": [{"kty": "RSA", "kid": "rsa", "n": _b64url(modulus), "e": _b64url(exponent)}]
-    }
+    jwks_large = {"keys": [{"kty": "RSA", "kid": "rsa", "n": _b64url(modulus), "e": _b64url(exponent)}]}
     authenticator = OidcAuthenticator(
         provider,
         jwks_fetcher=lambda _: jwks_large,
@@ -1623,9 +1608,7 @@ def test_oidc_authenticator_claim_validation_edge_cases() -> None:
     authenticator_no_iat = OidcAuthenticator(
         provider,
         defaults=defaults,
-        jwks_fetcher=lambda _: {
-            "keys": [{"kty": "oct", "kid": "primary", "k": _b64url(secret)}]
-        },
+        jwks_fetcher=lambda _: {"keys": [{"kty": "oct", "kid": "primary", "k": _b64url(secret)}]},
         secret_resolver=resolver,
     )
     missing_exp_claims = {
@@ -1644,9 +1627,7 @@ def test_oidc_authenticator_claim_validation_edge_cases() -> None:
         default_token_ttl_seconds=60,
         max_token_age_seconds=None,
     )
-    authenticator_ttl, provider_ttl, secret_ttl, _ = _build_oidc_authenticator(
-        now=now, defaults=ttl_defaults
-    )
+    authenticator_ttl, provider_ttl, secret_ttl, _ = _build_oidc_authenticator(now=now, defaults=ttl_defaults)
     ttl_claims = {
         "iss": provider_ttl.issuer,
         "aud": provider_ttl.client_id,
@@ -1736,6 +1717,7 @@ def test_default_jwks_fetcher(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(AuthenticationError) as exc:
         authentication_module._default_jwks_fetcher("https://example.com/jwks")
     assert str(exc.value) == "jwks_fetch_failed"
+
 
 def test_saml_authenticator_error_paths() -> None:
     now = dt.datetime.now(dt.timezone.utc)
@@ -1997,9 +1979,7 @@ def test_saml_authenticator_allows_missing_temporal_attributes() -> None:
     )
     authenticator = SamlAuthenticator(provider)
     subject = "user@example.com"
-    signature = _b64url(
-        hmac.new(provider.certificate.encode(), subject.encode(), hashlib.sha256).digest()
-    )
+    signature = _b64url(hmac.new(provider.certificate.encode(), subject.encode(), hashlib.sha256).digest())
     assertion = (
         "<Assertion xmlns='urn:oasis:names:tc:SAML:2.0:assertion'>"
         "<Subject>"
@@ -2028,9 +2008,7 @@ def test_saml_authenticator_rejects_future_subject_confirmation() -> None:
     )
     authenticator = SamlAuthenticator(provider)
     subject = "user@example.com"
-    signature = _b64url(
-        hmac.new(provider.certificate.encode(), subject.encode(), hashlib.sha256).digest()
-    )
+    signature = _b64url(hmac.new(provider.certificate.encode(), subject.encode(), hashlib.sha256).digest())
     conditions_not_before = _saml_instant(now - dt.timedelta(minutes=5))
     conditions_not_on_or_after = _saml_instant(now + dt.timedelta(minutes=5))
     confirmation_not_before = _saml_instant(now + dt.timedelta(minutes=5))

--- a/tests/test_chatops.py
+++ b/tests/test_chatops.py
@@ -278,9 +278,7 @@ async def test_chatops_instrumentation_success(monkeypatch: pytest.MonkeyPatch) 
             default_channel="#ops",
         ),
     )
-    observability = Observability(
-        ObservabilityConfig(datadog_tags=(("env", "test"),), sentry_record_breadcrumbs=True)
-    )
+    observability = Observability(ObservabilityConfig(datadog_tags=(("env", "test"),), sentry_record_breadcrumbs=True))
     service = ChatOpsService(config, transport=transport, observability=observability)
 
     tenant = TenantContext(tenant="acme", site="demo", domain="example.com", scope=TenantScope.TENANT)
@@ -491,9 +489,7 @@ async def test_chatops_instrumentation_sentry_breadcrumbs_without_channel(
         enabled=True,
         default=SlackWebhookConfig(webhook_url="https://hooks.slack.com/services/token"),
     )
-    observability = Observability(
-        ObservabilityConfig(datadog_enabled=False, sentry_record_breadcrumbs=True)
-    )
+    observability = Observability(ObservabilityConfig(datadog_enabled=False, sentry_record_breadcrumbs=True))
     service = ChatOpsService(config, transport=RecordingTransport(), observability=observability)
     tenant = TenantContext(tenant="acme", site="demo", domain="example.com", scope=TenantScope.TENANT)
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -62,11 +62,7 @@ def _build_spec() -> dict[str, Any]:
                     "responses": {
                         "201": {
                             "description": "Created",
-                            "content": {
-                                "application/json": {
-                                    "schema": {"$ref": "#/components/schemas/Widget"}
-                                }
-                            },
+                            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Widget"}}},
                         }
                     },
                 }
@@ -80,9 +76,7 @@ def _build_spec() -> dict[str, Any]:
             "/other": {
                 "patch": {
                     "operationId": "!special-case!",
-                    "requestBody": {
-                        "content": {"application/x-custom": {"schema": {"type": "string"}}}
-                    },
+                    "requestBody": {"content": {"application/x-custom": {"schema": {"type": "string"}}}},
                     "responses": {
                         "202": {
                             "description": "Accepted",
@@ -99,9 +93,9 @@ def test_generate_typescript_client_emits_strict_types() -> None:
     spec = _build_spec()
     source = generate_typescript_client(spec)
     assert "export interface Widget {" in source
-    assert "export type OnlyEnum = \"alpha\" | \"beta\" | 3;" in source
+    assert 'export type OnlyEnum = "alpha" | "beta" | 3;' in source
     assert "export type MaybeNumber = number | null;" in source
-    assert "export type LiteralValue = {\"kind\": \"literal\"};" in source
+    assert 'export type LiteralValue = {"kind": "literal"};' in source
     assert "export type MultiType = string | null;" in source
     assert "export interface Dictionary {" in source
     assert "export type UnknownType = unknown;" in source
@@ -151,7 +145,7 @@ def test_generate_client_without_paths() -> None:
 def test_schema_renderer_handles_combinations() -> None:
     renderer = ts_codegen._SchemaRenderer(_build_spec()["components"]["schemas"])
     assert renderer.render_type({"$ref": "#/components/schemas/Widget"}) == "Widget"
-    assert renderer.render_type({"enum": ["one", 2]}) == '\"one\" | 2'
+    assert renderer.render_type({"enum": ["one", 2]}) == '"one" | 2'
     assert renderer.render_type({"const": True}) == "true"
     assert renderer.render_type({"type": ["string", "null"]}) == "string | null"
     assert renderer.render_type({"type": "array", "items": {"type": "integer"}}) == "Array<number>"
@@ -173,14 +167,16 @@ def test_operation_helpers_cover_edge_cases() -> None:
     assert ts_codegen._sanitize_operation_id("123") == "op_123"
     assert ts_codegen._type_name_from_path("/", "GET") == "RootGet"
     assert ts_codegen._type_name_from_path("/123/resource", "POST") == "Route123ResourcePost"
-    request_body = ts_codegen._select_request_body({
-        "requestBody": {
-            "content": {
-                "application/json": {"schema": {"type": "object"}},
-                "text/plain": {"schema": {"type": "string"}},
+    request_body = ts_codegen._select_request_body(
+        {
+            "requestBody": {
+                "content": {
+                    "application/json": {"schema": {"type": "object"}},
+                    "text/plain": {"schema": {"type": "string"}},
+                }
             }
         }
-    })
+    )
     assert request_body == ("application/json", {"type": "object"})
     fallback_body = ts_codegen._select_request_body(
         {"requestBody": {"content": {"text/plain": {"schema": {"type": "string"}}}}}

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -104,5 +104,3 @@ async def test_request_response_recording() -> None:
         assert response.status == 200
         await client.post("/items", tenant="acme", json={"name": "Sample"}, label="create_item")
     recorder.finalize()
-
-

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -35,20 +35,18 @@ def test_golden_ensure_writes_when_approved(tmp_path: Path, monkeypatch: pytest.
 
 def test_golden_detects_differences(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     path = tmp_path / "value.json"
-    path.write_text("{\n  \"value\": 1\n}\n")
+    path.write_text('{\n  "value": 1\n}\n')
     golden = GoldenFile(path)
     monkeypatch.delenv("ARTEMIS_APPROVE_GOLDEN", raising=False)
     with pytest.raises(AssertionError) as excinfo:
         golden.ensure({"value": 2})
     message = str(excinfo.value)
     assert "Set ARTEMIS_APPROVE_GOLDEN=1 to approve updates." in message
-    assert "-  \"value\": 1" in message
-    assert "+  \"value\": 2" in message
+    assert '-  "value": 1' in message
+    assert '+  "value": 2' in message
 
 
-def test_request_response_recorder_serializes_payloads(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_request_response_recorder_serializes_payloads(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     path = tmp_path / "recordings.json"
     golden = GoldenFile(path)
     monkeypatch.setenv("ARTEMIS_APPROVE_GOLDEN", "1")

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -137,9 +137,7 @@ def test_generate_openapi_handles_docstrings_and_skips_parameters() -> None:
     request_schema = operation["requestBody"]["content"]["application/json"]["schema"]
     assert request_schema == {"$ref": "#/components/schemas/DocPayload"}
     awaitable_response = spec["paths"]["/awaitable"]["get"]["responses"]["200"]
-    assert awaitable_response["content"]["application/json"]["schema"] == {
-        "$ref": "#/components/schemas/Result"
-    }
+    assert awaitable_response["content"]["application/json"]["schema"] == {"$ref": "#/components/schemas/Result"}
 
 
 def test_generate_openapi_without_components() -> None:

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -3927,9 +3927,7 @@ async def test_quickstart_delegation_routes_delegate(
 async def test_quickstart_cedar_dependency_handles_missing_workspace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def stub_build(
-        orm: quickstart.ORM, *, tenant: TenantContext, at: dt.datetime | None = None
-    ) -> CedarEngine:
+    async def stub_build(orm: quickstart.ORM, *, tenant: TenantContext, at: dt.datetime | None = None) -> CedarEngine:
         if tenant.scope is TenantScope.TENANT and tenant.tenant == "acme":
             return CedarEngine(())
         raise HTTPError(Status.NOT_FOUND, {"detail": "missing"})

--- a/tests/test_quickstart_services.py
+++ b/tests/test_quickstart_services.py
@@ -83,9 +83,7 @@ class InMemoryTable:
         limit: int | None = None,
     ) -> list[Any]:
         bucket = [
-            record
-            for record in self._storage.get(self._bucket_key(tenant), ())
-            if self._matches(record, filters)
+            record for record in self._storage.get(self._bucket_key(tenant), ()) if self._matches(record, filters)
         ]
         if order_by:
             field, *rest = next(iter(order_by)).split()
@@ -902,8 +900,7 @@ async def test_build_cedar_engine_includes_assignments_and_delegations(
     policies = list(engine.policies())
     assert len(policies) == 3
     assert any(
-        policy.principal == CedarReference("User", "delegate") and "tiles:view" in policy.actions
-        for policy in policies
+        policy.principal == CedarReference("User", "delegate") and "tiles:view" in policy.actions for policy in policies
     )
     analyst = CedarEntity(type="User", id="analyst")
     resource = CedarEntity(type="workspace", id=tenant_alpha.tenant)


### PR DESCRIPTION
## Summary
- run ruff format across the codebase to normalize layout and spacing
- reorder typing imports and __all__ exports in chatops module so ruff lint passes

## Testing
- uv run ruff check
- uv run ruff format
- uv run ty check src
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7325fb2e4832eac9277080e7fe0d7