### PR TITLE
Handle list responses from support ticket updates

### DIFF
--- a/src/artemis/quickstart.py
+++ b/src/artemis/quickstart.py
@@ -1116,6 +1116,13 @@ class QuickstartAdminControlPlane:
                 "updated_by": actor,
             },
         )
+        if isinstance(updated, Sequence):
+            updated_record = cast(
+                QuickstartSupportTicketRecord,
+                updated[0] if updated else record,
+            )
+        else:
+            updated_record = cast(QuickstartSupportTicketRecord, updated)
         tenant_context = self._app.tenant_resolver.context_for(record.tenant_slug, TenantScope.TENANT)
         tenant_record = await orm.tenants.support_tickets.get(
             tenant=tenant_context,
@@ -1150,7 +1157,7 @@ class QuickstartAdminControlPlane:
                 "note": payload.note,
             },
         )
-        return cast(QuickstartSupportTicketRecord, updated)
+        return updated_record
 
 
 def attach_quickstart(


### PR DESCRIPTION
## Summary
- ensure `QuickstartAdminControlPlane.update_support_ticket` returns a concrete model when the ORM update yields a sequence
- keep the admin support ticket route returning a single JSON object while adjusting for list-based updates
- add a regression test covering a list-returning mocked update manager

## Testing
- `uv run pytest tests/test_quickstart.py::test_quickstart_admin_support_ticket_update_sequence_response` *(fails coverage threshold when run in isolation)*

------
https://chatgpt.com/codex/tasks/task_e_68d742bac0e8832eae345bbd14e5acc5