### PR TITLE
Handle missing and invalid ASGI headers safely

### DIFF
--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -8,7 +8,7 @@ from artemis.application import ArtemisApp
 from artemis.config import AppConfig
 from artemis.requests import Request
 from artemis.responses import Response
-from artemis.serialization import json_encode
+from artemis.serialization import json_decode, json_encode
 
 
 @pytest.mark.asyncio
@@ -56,15 +56,19 @@ async def test_asgi_requires_host_header() -> None:
     async def ping() -> str:
         return "pong"
 
+    messages: list[dict[str, object]] = []
+
     async def receive() -> Mapping[str, object]:
         return {"type": "http.request", "body": b"", "more_body": False}
 
     async def send(message: Mapping[str, object]) -> None:
-        raise AssertionError("send should not be called")
+        messages.append(dict(message))
 
     scope = {"type": "http", "method": "GET", "path": "/ping", "query_string": b"", "headers": []}
-    with pytest.raises(RuntimeError):
-        await app(scope, receive, send)
+    await app(scope, receive, send)
+    assert messages[0]["status"] == 400
+    payload = json_decode(messages[-1]["body"])
+    assert payload["error"]["detail"]["detail"] == "missing_host_header"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- return protocol-level errors when ASGI headers cannot be decoded or when the host header is absent before dispatching
- broaden regression tests to cover missing-host and unencodable header scenarios for both HTTP and WebSocket scopes

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d8f4770070832e88dc91eed7444968