### PR TITLE
Add bundled quickstart example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ point the quickstart at tenant data that matches their sandbox. Copy `.env.examp
 payload, and run local services with `uv run --env-file .env <command>` (or export the variables directly in
 your shell). When enabled it provides:
 
+The repository ships with [`example.py`](example.py) so you can kick the tyres immediately:
+
+```bash
+uv sync
+uv run example.py
+```
+
+The script starts a Granian server with the quickstart bundle wired in. Override `MERE_SITE`, `MERE_DOMAIN`,
+`MERE_ALLOWED_TENANTS`, `MERE_HOST`, or `MERE_PORT` to tailor the tenancy hostnames and bind address. Provide a
+`DATABASE_URL` when you want the quickstart tables to persist in PostgreSQL; otherwise the demo operates purely
+in memory.
+
 * **Diagnostics:** `/__mere/ping`, OpenAPI JSON, and a generated TypeScript client that all resolve for
   every tenant host (`*.site.domain`), including the admin control plane (`admin.site.domain`).
 * **Authentication flows:** fully tenant-aware login endpoints that model SSO, passkey, password, and MFA

--- a/example.py
+++ b/example.py
@@ -1,0 +1,86 @@
+"""Minimal Mere application that ships with the framework.
+
+Run ``uv sync`` once, then ``uv run example.py`` to boot a local Mere app with the
+quickstart bundle enabled. The server exposes the built-in authentication flows
+under ``/__mere`` alongside a small JSON route at ``/`` that echoes the resolved
+tenant.
+
+By default the example expects tenant hosts like ``acme.demo.local.test`` and
+``beta.demo.local.test``. Override ``MERE_SITE``, ``MERE_DOMAIN``, or
+``MERE_ALLOWED_TENANTS`` to match your environment. Provide ``DATABASE_URL`` to
+back the quickstart with PostgreSQL; when omitted the demo operates in memory.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+from mere import AppConfig, MereApp, attach_quickstart
+from mere.database import DatabaseConfig, PoolConfig
+from mere.requests import Request
+from mere.responses import JSONResponse, Response
+from mere.server import ServerConfig, run
+
+
+def _parse_allowed_tenants(raw: str | None) -> tuple[str, ...]:
+    """Return a sorted tuple of tenant slugs for the quickstart resolver."""
+
+    if not raw:
+        return ("acme", "beta")
+    candidates: Iterable[str] = (tenant.strip() for tenant in raw.split(","))
+    cleaned = sorted({tenant for tenant in candidates if tenant})
+    return tuple(cleaned) or ("acme", "beta")
+
+
+def _database_config() -> DatabaseConfig | None:
+    """Build a database configuration when ``DATABASE_URL`` is present."""
+
+    dsn = os.getenv("DATABASE_URL")
+    if not dsn:
+        return None
+    return DatabaseConfig(pool=PoolConfig(dsn=dsn))
+
+
+def create_app() -> MereApp:
+    """Instantiate the demo application with quickstart routes attached."""
+
+    config = AppConfig(
+        site=os.getenv("MERE_SITE", "demo"),
+        domain=os.getenv("MERE_DOMAIN", "local.test"),
+        allowed_tenants=_parse_allowed_tenants(os.getenv("MERE_ALLOWED_TENANTS")),
+        database=_database_config(),
+    )
+    app = MereApp(config)
+    attach_quickstart(app)
+
+    @app.get("/", name="root")
+    async def root(request: Request) -> Response:
+        tenant = request.tenant
+        return JSONResponse(
+            {
+                "message": "Mere quickstart is ready",
+                "tenant": tenant.tenant,
+                "scope": tenant.scope.value,
+                "host": tenant.host,
+            }
+        )
+
+    return app
+
+
+def main() -> None:
+    """Boot the Granian development server."""
+
+    app = create_app()
+    host = os.getenv("MERE_HOST", "127.0.0.1")
+    port = int(os.getenv("MERE_PORT", "8000"))
+    print(
+        "Serving Mere quickstart example on Granian at http://%s:%d (tenants: %s)"
+        % (host, port, ", ".join(app.tenant_resolver.allowed_tenants) or "<none>")
+    )
+    run(app, ServerConfig(host=host, port=port))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `example.py` that builds a MereApp, wires in the quickstart bundle, and runs Granian
- document how to launch the bundled example and override tenancy or database settings

## Testing
- uv run ruff format
- uv run ruff check
- uv run ty check
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68da6d8e2c40832e8d0cd1a1304e7fca