### PR TITLE
Improve quickstart workspace coverage

### DIFF
--- a/src/mere/domain/services.py
+++ b/src/mere/domain/services.py
@@ -55,6 +55,23 @@ class TileRecord(msgspec.Struct, frozen=True, omit_defaults=True):
 class TileService(Protocol):
     """Manage dashboard tiles while enforcing RBAC."""
 
+    async def list_tiles(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        principal: CedarEntity | None,
+    ) -> tuple[TileRecord, ...]: ...
+
+    async def get_tile(
+        self,
+        *,
+        tenant: TenantContext,
+        workspace_id: str,
+        tile_id: str,
+        principal: CedarEntity | None,
+    ) -> TileRecord: ...
+
     async def create_tile(
         self,
         *,


### PR DESCRIPTION
## Summary
- add workspace settings, notifications, and kanban read endpoints with typed responses and seeded fallbacks
- extend the tile service protocol/implementation and OpenAPI response handling so the new APIs expose usable schemas
- expand quickstart and OpenAPI tests to cover workspace data fallbacks, access checks, and response metadata

## Testing
- uv run ruff format tests/test_quickstart.py
- uv run ruff check
- uv run ty check
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3114e28b0832e9de1badb82a8a656