### PR TITLE
Ensure bootstrap prepares admin schema before migrations

### DIFF
--- a/src/mere/bootstrap.py
+++ b/src/mere/bootstrap.py
@@ -663,9 +663,10 @@ def bootstrap_migrations() -> tuple[Migration, ...]:
 
 
 async def ensure_tenant_schemas(database: Database, tenants: Sequence[TenantContext]) -> None:
-    """Create tenant schemas for the bootstrap if they do not already exist."""
+    """Create the admin and tenant schemas required by the bootstrap."""
 
-    schemas = {database.config.schema_for_tenant(tenant) for tenant in tenants}
+    schemas = {database.config.admin_schema}
+    schemas.update(database.config.schema_for_tenant(tenant) for tenant in tenants)
     async with database.connection(schema=database.config.admin_schema) as connection:
         for schema in sorted(schemas):
             await connection.execute(f"CREATE SCHEMA IF NOT EXISTS {_quote_identifier(schema)}")

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -2654,12 +2654,13 @@ async def test_attach_bootstrap_bootstraps_database(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
-async def test_ensure_tenant_schemas_handles_empty() -> None:
+async def test_ensure_tenant_schemas_creates_admin_schema_when_no_tenants() -> None:
     pool = FakePool()
     db_config = DatabaseConfig(pool=PoolConfig(dsn="postgres://bootstrap"))
     database = Database(db_config, pool=pool)
     await ensure_tenant_schemas(database, [])
-    assert all("CREATE SCHEMA" not in sql for _, sql, *_ in pool.connection.calls)
+    statements = [sql for kind, sql, *_ in pool.connection.calls if kind == "execute"]
+    assert any("CREATE SCHEMA" in sql and '"admin"' in sql for sql in statements)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ensure the bootstrap schema helper always creates the admin schema alongside tenant schemas
- update the bootstrap schema test to assert admin schema creation without tenants

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e43d0e989c832e929f4cbb5877aba4